### PR TITLE
using local uid and gid in extraction

### DIFF
--- a/cmd/scripts/extract.sh
+++ b/cmd/scripts/extract.sh
@@ -37,4 +37,4 @@ else
 fi
 
 # set permissions for the export path
-chown -R 1000:1000 "$EXPORT_PATH" 2>/dev/null || true
+chown -R "$(id -u):$(id -g)" "$EXPORT_PATH" 2>/dev/null || true


### PR DESCRIPTION
Uses uid and gid of user running Coral instead of 1000:1000 when extracting and setting ownership of files from components to enable use on systems with nonstandard permissions settings.