### PR TITLE
absolute volume expansion for all cases

### DIFF
--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -196,6 +196,15 @@ func verify(imageName string, envFile string) error {
 		return fmt.Errorf("/ws does not exist or is not a directory in image %q", imageName)
 	}
 
+	// make sure /export does not exist
+	checkExportCmd := exec.Command("docker", "run", "--rm",
+		"--entrypoint", "sh",
+		imageName,
+		"-c", "test ! -d /export")
+	if err := checkExportCmd.Run(); err != nil {
+		return fmt.Errorf("/export directory already exists in image %q; please remove it", imageName)
+	}
+
 	// run the extraction step
 	_, err = extractor.ExtractImage(imageName, "coral", tempDir, verifyEntrypoint)
 	if err != nil {


### PR DESCRIPTION
Altered absolute volume remapping to work when docker.yaml file is not found within container (previously only expanded volumes when this file was exported) and added extra safety check in verify to make sure /export directory used in the extraction step does not exist.