### PR TITLE
Adding manual override via environment variables for UID and GID ownership of extracted files 

### DIFF
--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -172,8 +172,14 @@ func verify(imageName string, envFile string) error {
 		tempDir = filepath.Join(hostLibPath, relPath)
 	}
 
-	uid := os.Getuid()
-	gid := os.Getgid()
+	uid, err := io.GetUID()
+	if err != nil {
+		return fmt.Errorf("failed to get UID: %w", err)
+	}
+	gid, err := io.GetGID()
+	if err != nil {
+		return fmt.Errorf("failed to get GID: %w", err)
+	}
 
 	// make sure /ws exists and has proper ownership
 	checkCmd := exec.Command("docker", "run", "--rm",

--- a/internal/extractor/extractor.go
+++ b/internal/extractor/extractor.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 
 	"github.com/enescakir/emoji"
+
+	"coral_cli/internal/io"
 )
 
 func ExtractImage(image string, name string, libPath string, extractionEntrypoint string) (string, error) {
@@ -16,6 +18,15 @@ func ExtractImage(image string, name string, libPath string, extractionEntrypoin
 	}
 	imageID = imageID + "-coral-" + name
 
+	uid, err := io.GetUID()
+	if err != nil {
+		return "", fmt.Errorf("failed to get UID: %w", err)
+	}
+	gid, err := io.GetGID()
+	if err != nil {
+		return "", fmt.Errorf("failed to get GID: %w", err)
+	}
+
 	cmd := exec.Command(
 		"docker", "run", "--rm",
 		"--name", "coral-"+name,
@@ -23,7 +34,7 @@ func ExtractImage(image string, name string, libPath string, extractionEntrypoin
 		"-e", "EXPORT_PATH=/export",
 		"-v", fmt.Sprintf("%s:/export", libPath),
 		"-v", fmt.Sprintf("%s:/extract.sh", extractionEntrypoint),
-		"--user", fmt.Sprintf("%d:%d", os.Getuid(), os.Getgid()),
+		"--user", fmt.Sprintf("%d:%d", uid, gid),
 		"--entrypoint", "/extract.sh",
 		image,
 	)

--- a/internal/io/io.go
+++ b/internal/io/io.go
@@ -3,6 +3,7 @@ package io
 import (
 	"fmt"
 	"os"
+	"strconv"
 )
 
 func ResolveComposeFile(userPath string) (string, error) {
@@ -26,4 +27,20 @@ func ResolveEnvFile(userPath string) (string, error) {
 		return ".env", nil
 	}
 	return "", nil
+}
+
+func GetUID() (int, error) {
+	uid := os.Getenv("CORAL_UID")
+	if uid == "" {
+		return os.Getuid(), nil
+	}
+	return strconv.Atoi(uid)
+}
+
+func GetGID() (int, error) {
+	gid := os.Getenv("CORAL_GID")
+	if gid == "" {
+		return os.Getgid(), nil
+	}
+	return strconv.Atoi(gid)
 }


### PR DESCRIPTION
Useful for situations when running Coral commands in two separate environments/containers with different users and need consistent file ownership.