### PR TITLE
v2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 # ---- configuration ----
 BINARY_NAME := coral
 INSTALL_DIR := /usr/local/bin
+VERSION ?= $(shell git describe --tags --always 2>/dev/null || echo "dev")
 
 BASH_COMPLETION_DIR := /usr/share/bash-completion/completions
 ZSH_COMPLETION_DIR := /usr/share/zsh/site-functions
@@ -14,7 +15,7 @@ all: build
 build:
 	@echo "==> Building $(BINARY_NAME)..."
 	@mkdir -p bin
-	@go build -o bin/$(BINARY_NAME)
+	@go build -ldflags "-X 'coral_cli/cmd.Version=$(VERSION)'" -o bin/$(BINARY_NAME)
 	@echo "==> Wrote to ./bin/$(BINARY_NAME)"
 
 .PHONY: clean

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -38,7 +38,8 @@ var (
 	launchExecutorDelay float32
 	launchProfiles      []string
 	launchLibDir        string
-	launchHealthTimeout float32
+	launchHealthTimeout    float32
+	launchSkipVersionCheck bool
 )
 
 func init() {
@@ -54,6 +55,7 @@ func init() {
 	launchCmd.Flags().StringSliceVarP(&launchProfiles, "profile", "p", []string{}, "List of profiles to launch (drivers, skillsets, executors); if not specified, all profiles will be launched")
 	launchCmd.Flags().StringVar(&launchLibDir, "lib-dir", "", "Override CORAL_LIB path (takes precedence over $CORAL_LIB environment variable)")
 	launchCmd.Flags().Float32Var(&launchHealthTimeout, "health-timeout", 120.0, "Seconds to wait for drivers/skillsets to become healthy before starting executors")
+	launchCmd.Flags().BoolVar(&launchSkipVersionCheck, "skip-version-check", false, "Skip coral.version compatibility check between CLI and images")
 
 	launchCmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		if toComplete == "" {
@@ -132,12 +134,12 @@ var launchCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return launch(launchComposePath, launchEnvFile, launchHandle, launchGroup,
 			launchDetached, launchKill, launchExecutorDelay, launchHealthTimeout,
-			launchLibDir, launchProfiles)
+			launchLibDir, launchProfiles, launchSkipVersionCheck)
 	},
 }
 
 func launch(composePath, envFile, handle, group string, detached, kill bool,
-	executorDelay, healthTimeout float32, libDirOverride string, profilesToStart []string) error {
+	executorDelay, healthTimeout float32, libDirOverride string, profilesToStart []string, skipVersionCheck bool) error {
 
 	signalChan := make(chan os.Signal, 1)
 	signal.Notify(signalChan, os.Interrupt, syscall.SIGINT, syscall.SIGTERM)
@@ -212,7 +214,7 @@ func launch(composePath, envFile, handle, group string, detached, kill bool,
 		}
 	}
 
-	if err := checkImagesLocal(parsedCompose); err != nil {
+	if err := checkImagesLocal(parsedCompose, skipVersionCheck); err != nil {
 		return fmt.Errorf("checking images: %w", err)
 	}
 
@@ -306,7 +308,10 @@ func launch(composePath, envFile, handle, group string, detached, kill bool,
 
 var validProfiles = map[string]bool{"drivers": true, "skillsets": true, "executors": true}
 
-func checkImagesLocal(cf *compose.ComposeFile) error {
+func checkImagesLocal(cf *compose.ComposeFile, skipVersionCheck bool) error {
+	selfMajor, err := parseMajorVersion(Version)
+	checkVersion := !skipVersionCheck && err == nil // skip for dev builds or when flag is set
+
 	for name, svc := range cf.Services {
 		raw, ok := svc["image"]
 		if !ok || raw == nil {
@@ -329,6 +334,20 @@ func checkImagesLocal(cf *compose.ComposeFile) error {
 		}
 		if !validProfiles[profile] {
 			return fmt.Errorf("image %s (service %s) has invalid coral.profile %q: must be one of drivers, skillsets, executors", image, name, profile)
+		}
+		if checkVersion {
+			coralVer := labels["coral.version"]
+			if coralVer == "" {
+				return fmt.Errorf("image %s (service %s) is missing required label coral.version", image, name)
+			}
+			imageMajor, err := parseMajorVersion(coralVer)
+			if err != nil {
+				return fmt.Errorf("image %s (service %s) has unparseable coral.version %q: %w", image, name, coralVer, err)
+			}
+			if imageMajor != selfMajor {
+				return fmt.Errorf("image %s (service %s) coral.version %q is incompatible with CLI version %s (major %d != %d)",
+					image, name, coralVer, Version, imageMajor, selfMajor)
+			}
 		}
 	}
 	return nil

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -212,7 +212,7 @@ func launch(composePath, envFile, handle, group string, detached, kill bool,
 		}
 	}
 
-	if err := checkImagesLocal(parsedCompose, profilesToStart); err != nil {
+	if err := checkImagesLocal(parsedCompose); err != nil {
 		return fmt.Errorf("checking images: %w", err)
 	}
 
@@ -303,7 +303,9 @@ func launch(composePath, envFile, handle, group string, detached, kill bool,
 	return runForeground(profiles, instanceName, outputPath, kill, executorDelay, healthTimeout, profilesMap, reg)
 }
 
-func checkImagesLocal(cf *compose.ComposeFile, profilesToStart []string) error {
+var validProfiles = map[string]bool{"drivers": true, "skillsets": true, "executors": true}
+
+func checkImagesLocal(cf *compose.ComposeFile) error {
 	for name, svc := range cf.Services {
 		raw, ok := svc["image"]
 		if !ok || raw == nil {
@@ -313,12 +315,19 @@ func checkImagesLocal(cf *compose.ComposeFile, profilesToStart []string) error {
 		if !ok {
 			return fmt.Errorf("expected string for 'image' in service %s", name)
 		}
-		profs := extractServiceProfiles(svc)
-		if len(profilesToStart) > 0 && !hasIntersection(profs, profilesToStart) {
-			continue
-		}
 		if _, err := libs.GetImageID(image); err != nil {
 			return fmt.Errorf("checking image %s for service %s: %w", image, name, err)
+		}
+		labels, err := libs.GetImageLabels(image)
+		if err != nil {
+			return fmt.Errorf("reading labels for service %s: %w", name, err)
+		}
+		profile := labels["coral.profile"]
+		if profile == "" {
+			return fmt.Errorf("image %s (service %s) is missing required label coral.profile", image, name)
+		}
+		if !validProfiles[profile] {
+			return fmt.Errorf("image %s (service %s) has invalid coral.profile %q: must be one of drivers, skillsets, executors", image, name, profile)
 		}
 	}
 	return nil
@@ -346,20 +355,25 @@ func buildMergedCompose(cf *compose.ComposeFile, lib, hostLib string,
 
 	for name, svc := range cf.Services {
 		image := svc["image"].(string)
-		profs := extractServiceProfiles(svc)
+		labels, err := libs.GetImageLabels(image)
+		if err != nil {
+			return nil, nil, fmt.Errorf("reading labels for service %s: %w", name, err)
+		}
+		profile := labels["coral.profile"] // already validated non-empty and valid in checkImagesLocal
 
-		if len(profilesToStart) > 0 && !hasIntersection(profs, profilesToStart) {
-			continue
+		if len(profilesToStart) > 0 {
+			matched := false
+			for _, p := range profilesToStart {
+				if p == profile {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				continue
+			}
 		}
-		validProfiles := []string{"drivers", "skillsets", "executors"}
-		if !hasIntersection(profs, validProfiles) {
-			fmt.Println(logging.Warning(fmt.Sprintf(
-				"Skipping %s — no valid profiles %v", name, validProfiles)))
-			continue
-		}
-		for _, p := range profs {
-			profilesMap[p] = append(profilesMap[p], name)
-		}
+		profilesMap[profile] = append(profilesMap[profile], name)
 
 		stagingDir, imageID, err := libs.ExtractLibraries(image, name, lib)
 		if err != nil {
@@ -436,6 +450,7 @@ func buildMergedCompose(cf *compose.ComposeFile, lib, hostLib string,
 			}
 		}
 
+		mergedSvc["profiles"] = []interface{}{profile}
 		merged["services"].(map[string]interface{})[name] = mergedSvc
 	}
 
@@ -612,32 +627,6 @@ func runForeground(profiles []string, instanceName, composePath string, kill boo
 	return nil
 }
 
-func hasIntersection(a, b []string) bool {
-	set := make(map[string]struct{}, len(b))
-	for _, item := range b {
-		set[item] = struct{}{}
-	}
-	for _, item := range a {
-		if _, ok := set[item]; ok {
-			return true
-		}
-	}
-	return false
-}
-
-func extractServiceProfiles(service map[string]interface{}) []string {
-	var profiles []string
-	if raw, ok := service["profiles"]; ok {
-		if arr, ok := raw.([]interface{}); ok {
-			for _, p := range arr {
-				if str, ok := p.(string); ok {
-					profiles = append(profiles, str)
-				}
-			}
-		}
-	}
-	return profiles
-}
 
 func extractProfileNames(profiles map[string][]string) []string {
 	var names []string

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -216,7 +216,8 @@ func launch(composePath, envFile, handle, group string, detached, kill bool,
 		return fmt.Errorf("checking images: %w", err)
 	}
 
-	instanceName := fmt.Sprintf("coral-%s", uuid.New())
+	uid := uuid.New()
+	instanceName := fmt.Sprintf("coral-%x", uid[:4])
 	fmt.Println(logging.Info("Launching new instance " + logging.BoldMagentaHi(instanceName)))
 
 	// load (or create) the persistent registry

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -381,7 +381,7 @@ func buildMergedCompose(cf *compose.ComposeFile, lib, hostLib string,
 			return nil, nil, fmt.Errorf("extracting %s for service %s: %w", image, name, err)
 		}
 
-		if err := reg.RecordExtraction(imageID, stagingDir, imageID, instanceName); err != nil {
+		if err := reg.RecordExtraction(imageID, stagingDir, imageID, instanceName, labels["coral.btcpp_version"], labels["coral.ros_distro"]); err != nil {
 			fmt.Println(logging.Warning(fmt.Sprintf("recording extraction for %s: %v", name, err)))
 		}
 
@@ -474,14 +474,41 @@ func createAndStartExecutors(instanceName, composePath string, executorServices 
 		return fmt.Errorf("creating executor containers: %w", err)
 	}
 
-	allStagingDirs := reg.AllStagingDirs()
+	allExtractions := reg.AllExtractions()
 
 	for _, svc := range executorServices {
 		containerID, err := health.GetContainerIDForService(instanceName, svc)
 		if err != nil || containerID == "" {
 			return fmt.Errorf("locating container for executor service %s: %w", svc, err)
 		}
-		injected, err := libs.InjectLibraries(containerID, allStagingDirs)
+
+		execLabels, err := libs.GetContainerLabels(containerID)
+		if err != nil {
+			return fmt.Errorf("reading labels for executor %s: %w", svc, err)
+		}
+		execBtcpp := execLabels["coral.btcpp_version"]
+		execRos := execLabels["coral.ros_distro"]
+
+		compatibleDirs := make(map[string]string)
+		for imageID, rec := range allExtractions {
+			var reasons []string
+			if rec.BtcppVersion != execBtcpp {
+				reasons = append(reasons, fmt.Sprintf("BT.CPP version mismatch %q != %q", rec.BtcppVersion, execBtcpp))
+			}
+			if rec.RosDistro != execRos {
+				reasons = append(reasons, fmt.Sprintf("ROS distro mismatch %q != %q", rec.RosDistro, execRos))
+			}
+			if len(reasons) > 0 {
+				fmt.Println(logging.Warning(fmt.Sprintf(
+					"Cowardly refusing to inject libraries from %s into executor %s: %s",
+					rec.PayloadID, svc, strings.Join(reasons, ", "),
+				)))
+				continue
+			}
+			compatibleDirs[imageID] = rec.StagingDir
+		}
+
+		injected, err := libs.InjectLibraries(containerID, compatibleDirs)
 		if err != nil {
 			return fmt.Errorf("injecting libraries into %s: %w", svc, err)
 		}
@@ -627,7 +654,6 @@ func runForeground(profiles []string, instanceName, composePath string, kill boo
 
 	return nil
 }
-
 
 func extractProfileNames(profiles map[string][]string) []string {
 	var names []string

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -23,6 +23,8 @@ var rootCmd = &cobra.Command{
 		var err error
 
 		switch args[0] {
+		case "-v", "--version":
+			fmt.Printf("Coral version %s\n", Version)
 		case "images":
 			err = imagesCmd.RunE(cmd, args[1:])
 		case "ps":
@@ -64,4 +66,5 @@ func init() {
 	rootCmd.AddCommand(shutdownCmd)
 	rootCmd.AddCommand(tailCmd)
 	rootCmd.AddCommand(verifyCmd)
+	rootCmd.AddCommand(versionCmd)
 }

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -69,9 +69,9 @@ func verify(imageName string, libDir string) error {
 
 	_, _, err = libs.ExtractLibraries(imageName, "verify", tmpLib)
 	if err != nil {
-		return fmt.Errorf("extraction failed — ensure LIB_PATH is set and contains behaviors/ and interfaces/: %w", err)
+		return fmt.Errorf("extraction failed — ensure CORAL_EXPORT_LIB is set and contains behaviors/ and interfaces/: %w", err)
 	}
 
-	fmt.Println(logging.Info("LIB_PATH is set and library extraction succeeded"))
+	fmt.Println(logging.Info("CORAL_EXPORT_LIB is set and library extraction succeeded"))
 	return nil
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// overridden at build time via -ldflags "-X 'coral_cli/cmd.Version=vX.Y.Z'"
+var Version = "dev"
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the Coral version",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Printf("Coral version %s\n", Version)
+	},
+}
+
+// parseMajorVersion extracts the leading integer from a version string of the form [v]MAJOR[.MINOR[.PATCH[...]]].
+func parseMajorVersion(v string) (int, error) {
+	v = strings.TrimPrefix(v, "v")
+	if i := strings.IndexByte(v, '.'); i != -1 {
+		v = v[:i]
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return 0, fmt.Errorf("cannot parse major version from %q", v)
+	}
+	return n, nil
+}

--- a/internal/compose/devices.go
+++ b/internal/compose/devices.go
@@ -33,9 +33,7 @@ func LoadDevicesFile(path string) (*DevicesFile, error) {
 	return &df, nil
 }
 
-// ResolveDevicePaths resolves a DevicesFile to concrete host device paths for
-// Docker Compose's devices: list. Each returned entry is "<path>:<path>".
-// Returns an error if any declared USB device is not present on the host.
+// resolves a DevicesFile to concrete host device paths for Docker Compose's devices list; each returned entry is "<path>:<path>"
 func ResolveDevicePaths(df *DevicesFile, serviceName string) ([]string, error) {
 	var paths []string
 

--- a/internal/health/monitor.go
+++ b/internal/health/monitor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os/exec"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -17,8 +18,7 @@ type EventType int
 const (
 	EventContainerUnhealthy EventType = iota
 	EventContainerExited
-	// fires when a payload that contributed libraries to an executor is no longer running its skillset/driver backend; the executor itself is unaffected
-	// (libraries are already inside the container), but the behaviors may fail at runtime
+	// fires when a payload that contributed libraries to an executor is no longer running its skillset/driver backend; the executor itself is unaffected(libraries are already inside the container), but the behaviors may fail at runtime
 	EventLibraryDegraded
 )
 
@@ -64,6 +64,7 @@ func (m *Monitor) Start(ctx context.Context) <-chan HealthEvent {
 
 func (m *Monitor) poll(events chan<- HealthEvent, flagged map[string]bool) {
 	ids, err := GetContainerIDsForProject(m.instanceName)
+	fmt.Println(logging.Info(fmt.Sprintf("Checking health for project %s", m.instanceName)))
 	if err != nil || len(ids) == 0 {
 		return
 	}
@@ -71,24 +72,26 @@ func (m *Monitor) poll(events chan<- HealthEvent, flagged map[string]bool) {
 		if flagged[id] {
 			continue
 		}
-		status, svcName := containerStatus(id)
-		switch status {
+		cs := containerStatus(id)
+		switch cs.status {
 		case "unhealthy":
 			flagged[id] = true
-			events <- HealthEvent{Type: EventContainerUnhealthy, ContainerID: id, ServiceName: svcName, Detail: "health check failing"}
-			fmt.Println(logging.Warning(fmt.Sprintf("Container %s (%s) is unhealthy", shortID(id), svcName)))
+			events <- HealthEvent{Type: EventContainerUnhealthy, ContainerID: id, ServiceName: cs.serviceName, Detail: "health check failing"}
+			fmt.Println(logging.Warning(fmt.Sprintf("Container %s (%s) is unhealthy", shortID(id), cs.serviceName)))
 		case "exited", "dead":
 			flagged[id] = true
-			events <- HealthEvent{Type: EventContainerExited, ContainerID: id, ServiceName: svcName, Detail: "container exited"}
-			fmt.Println(logging.Warning(fmt.Sprintf("Container %s (%s) has exited unexpectedly", shortID(id), svcName)))
-			// Check whether any executor injections depended on this container's payload.
-			m.checkLibraryDegradation(id, svcName, events)
+			if cs.transient && cs.exitCode == 0 {
+				continue
+			}
+			events <- HealthEvent{Type: EventContainerExited, ContainerID: id, ServiceName: cs.serviceName, Detail: "container exited"}
+			fmt.Println(logging.Warning(fmt.Sprintf("Container %s (%s) has exited unexpectedly", shortID(id), cs.serviceName)))
+			// check whether any executor injections depended on this container's payload
+			m.checkLibraryDegradation(id, cs.serviceName, events)
 		}
 	}
 }
 
 func (m *Monitor) checkLibraryDegradation(deadContainerID, svcName string, events chan<- HealthEvent) {
-	// Use the service name as a proxy for payload ID (Phase 1; Phase 5 will use crex payload IDs).
 	affected := m.reg.GetExecutorsForPayload(svcName)
 	for _, rec := range affected {
 		if rec.ContainerID == deadContainerID {
@@ -122,8 +125,7 @@ func WaitForHealthy(ctx context.Context, instanceName string, services []string,
 				allReady = false
 				break
 			}
-			status, _ := containerStatus(id)
-			if !isReady(status) {
+			if !isReady(containerStatus(id)) {
 				allReady = false
 				break
 			}
@@ -140,22 +142,37 @@ func WaitForHealthy(ctx context.Context, instanceName string, services []string,
 	return fmt.Errorf("timed out waiting for services to become healthy: %v", services)
 }
 
-func isReady(status string) bool {
-	return status == "healthy" || status == "running_no_healthcheck"
+type containerState struct {
+	status      string
+	serviceName string
+	exitCode    int
+	transient   bool
 }
 
-// returns a normalised status and the compose service name
-func containerStatus(containerID string) (status, serviceName string) {
+func isReady(cs containerState) bool {
+	switch cs.status {
+	case "healthy", "running_no_healthcheck":
+		return true
+	case "exited", "dead":
+		return cs.transient && cs.exitCode == 0
+	}
+	return false
+}
+
+// returns normalised state for a container, including exit code and whether it bears the coral.transient label
+func containerStatus(containerID string) containerState {
 	cmd := exec.Command("docker", "inspect",
-		"--format", `{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}} {{.State.Status}} {{index .Config.Labels "com.docker.compose.service"}}`,
+		"--format", `{{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}} {{.State.Status}} {{index .Config.Labels "com.docker.compose.service"}} {{.State.ExitCode}} {{index .Config.Labels "coral.transient"}}`,
 		containerID)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	out, err := cmd.Output()
 	if err != nil {
-		return "unknown", ""
+		return containerState{status: "unknown"}
 	}
 	parts := strings.Fields(strings.TrimSpace(string(out)))
 	var health, state, svc string
+	var exitCode int
+	var transient bool
 	if len(parts) > 0 {
 		health = parts[0]
 	}
@@ -165,13 +182,25 @@ func containerStatus(containerID string) (status, serviceName string) {
 	if len(parts) > 2 {
 		svc = parts[2]
 	}
+	if len(parts) > 3 {
+		if n, err := strconv.Atoi(parts[3]); err == nil {
+			exitCode = n
+		}
+	}
+	if len(parts) > 4 {
+		transient = parts[4] == "true"
+	}
+	var status string
 	if health == "" || health == "none" {
 		if state == "running" {
-			return "running_no_healthcheck", svc
+			status = "running_no_healthcheck"
+		} else {
+			status = state
 		}
-		return state, svc
+	} else {
+		status = health
 	}
-	return health, svc
+	return containerState{status: status, serviceName: svc, exitCode: exitCode, transient: transient}
 }
 
 func GetContainerIDForService(instanceName, serviceName string) (string, error) {

--- a/internal/health/monitor.go
+++ b/internal/health/monitor.go
@@ -64,7 +64,6 @@ func (m *Monitor) Start(ctx context.Context) <-chan HealthEvent {
 
 func (m *Monitor) poll(events chan<- HealthEvent, flagged map[string]bool) {
 	ids, err := GetContainerIDsForProject(m.instanceName)
-	fmt.Println(logging.Info(fmt.Sprintf("Checking health for project %s", m.instanceName)))
 	if err != nil || len(ids) == 0 {
 		return
 	}
@@ -125,7 +124,11 @@ func WaitForHealthy(ctx context.Context, instanceName string, services []string,
 				allReady = false
 				break
 			}
-			if !isReady(containerStatus(id)) {
+			cs := containerStatus(id)
+			if (cs.status == "exited" || cs.status == "dead") && !isReady(cs) {
+				return fmt.Errorf("service %s exited unexpectedly (exit code %d)", svc, cs.exitCode)
+			}
+			if !isReady(cs) {
 				allReady = false
 				break
 			}

--- a/internal/libs/extract.go
+++ b/internal/libs/extract.go
@@ -28,7 +28,8 @@ func ExtractLibraries(image, name, lib string) (stagingDir string, imageID strin
 		return stagingDir, imageID, nil
 	}
 
-	probeName := fmt.Sprintf("coral-probe-%s", uuid.New())
+	uid := uuid.New()
+	probeName := fmt.Sprintf("coral-probe-%x", uid[:4])
 	createCmd := exec.Command("docker", "create", "--name", probeName, image)
 	createCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	out, err := createCmd.Output()

--- a/internal/libs/extract.go
+++ b/internal/libs/extract.go
@@ -14,7 +14,7 @@ import (
 	"github.com/google/uuid"
 )
 
-// probes an image by creating a stopped container, reading LIB_PATH from its environment, copying the library tree to staging/<imageID>/ under lib, then removing the probe container. docker.yaml (if present) stays inside the staging directory alongside the behavior/interface libraries; the caller is responsible for recording the extraction in the registry
+// probes an image by creating a stopped container, reading CORAL_EXPORT_LIB from its environment, copying the library tree to staging/<imageID>/ under lib, then removing the probe container. docker.yaml (if present) stays inside the staging directory alongside the behavior/interface libraries; the caller is responsible for recording the extraction in the registry
 func ExtractLibraries(image, name, lib string) (stagingDir string, imageID string, err error) {
 	imageID, err = GetImageID(image)
 	if err != nil {
@@ -43,12 +43,12 @@ func ExtractLibraries(image, name, lib string) (stagingDir string, imageID strin
 		rmCmd.Run() // best-effort
 	}()
 
-	libPath, err := readContainerEnv(containerID, "LIB_PATH")
+	libPath, err := readContainerEnv(containerID, "CORAL_EXPORT_LIB")
 	if err != nil {
-		return "", "", fmt.Errorf("reading LIB_PATH from %s: %w", image, err)
+		return "", "", fmt.Errorf("reading CORAL_EXPORT_LIB from %s: %w", image, err)
 	}
 	if libPath == "" {
-		return "", "", fmt.Errorf("image %s does not set LIB_PATH", image)
+		return "", "", fmt.Errorf("image %s does not set CORAL_EXPORT_LIB", image)
 	}
 
 	if err := os.MkdirAll(stagingDir, 0755); err != nil {
@@ -92,6 +92,24 @@ func readContainerEnv(containerID, varName string) (string, error) {
 		}
 	}
 	return "", nil
+}
+
+// returns the labels on the named image; the image must already be local
+func GetImageLabels(image string) (map[string]string, error) {
+	cmd := exec.Command("docker", "inspect", "--format", "{{json .Config.Labels}}", image)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("inspecting image %s: %w", image, err)
+	}
+	var labels map[string]string
+	if err := json.Unmarshal([]byte(strings.TrimSpace(string(out))), &labels); err != nil {
+		return nil, fmt.Errorf("parsing labels for image %s: %w", image, err)
+	}
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	return labels, nil
 }
 
 // returns the full image digest for the named image, pulling it if absent

--- a/internal/libs/extract.go
+++ b/internal/libs/extract.go
@@ -97,15 +97,24 @@ func readContainerEnv(containerID, varName string) (string, error) {
 
 // returns the labels on the named image; the image must already be local
 func GetImageLabels(image string) (map[string]string, error) {
-	cmd := exec.Command("docker", "inspect", "--format", "{{json .Config.Labels}}", image)
+	return inspectLabels(image)
+}
+
+// returns the labels on a created or running container; container labels include all image labels
+func GetContainerLabels(containerID string) (map[string]string, error) {
+	return inspectLabels(containerID)
+}
+
+func inspectLabels(dockerObject string) (map[string]string, error) {
+	cmd := exec.Command("docker", "inspect", "--format", "{{json .Config.Labels}}", dockerObject)
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	out, err := cmd.Output()
 	if err != nil {
-		return nil, fmt.Errorf("inspecting image %s: %w", image, err)
+		return nil, fmt.Errorf("inspecting %s: %w", dockerObject, err)
 	}
 	var labels map[string]string
 	if err := json.Unmarshal([]byte(strings.TrimSpace(string(out))), &labels); err != nil {
-		return nil, fmt.Errorf("parsing labels for image %s: %w", image, err)
+		return nil, fmt.Errorf("parsing labels for %s: %w", dockerObject, err)
 	}
 	if labels == nil {
 		labels = map[string]string{}

--- a/internal/libs/inject.go
+++ b/internal/libs/inject.go
@@ -19,7 +19,7 @@ type libEntry struct {
 	payloadID string
 }
 
-// merges behavior and interface libraries from all active staging directories into the executor container at /home/loading/lib (the path set by LOADING_LIBRARY_PATH in the coral_runner image); when two payloads provide a file with the same name in the same subdirectory (behaviors/ or interfaces/), the file with the newer modification timestamp wins and the losing entry is recorded as shadowed in the returned slice
+// merges behavior and interface libraries from all active staging directories into the executor container at the path given by CORAL_IMPORT_LIB in the container's environment; when two payloads provide a file with the same name in the same subdirectory (behaviors/ or interfaces/), the file with the newer modification timestamp wins and the losing entry is recorded as shadowed in the returned slice
 func InjectLibraries(containerID string, stagingDirs map[string]string) ([]registry.InjectedLib, error) {
 	if len(stagingDirs) == 0 {
 		return nil, nil
@@ -121,10 +121,18 @@ func InjectLibraries(containerID string, stagingDirs map[string]string) ([]regis
 		return result, nil
 	}
 
+	importLib, err := readContainerEnv(containerID, "CORAL_IMPORT_LIB")
+	if err != nil {
+		return nil, fmt.Errorf("reading CORAL_IMPORT_LIB from %s: %w", shortContainerID(containerID), err)
+	}
+	if importLib == "" {
+		return nil, fmt.Errorf("executor container %s does not set CORAL_IMPORT_LIB", shortContainerID(containerID))
+	}
+
 	// docker cp into the executor container
 	cpCmd := exec.Command("docker", "cp",
 		tmpDir+"/.",
-		fmt.Sprintf("%s:/home/loading/lib", containerID))
+		fmt.Sprintf("%s:%s", containerID, importLib))
 	cpCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 	if out, err := cpCmd.CombinedOutput(); err != nil {
 		return nil, fmt.Errorf("injecting libraries into %s: %w\n%s", shortContainerID(containerID), err, out)

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -10,10 +10,12 @@ import (
 
 // tracks what was extracted from a payload image into its staging directory; InstanceIDs is a reference-counted set: every instance that has referenced (extracted or injected from) this staging directory holds a slot
 type ExtractionRecord struct {
-	ImageID     string   `json:"image_id"`
-	StagingDir  string   `json:"staging_dir"`
-	PayloadID   string   `json:"payload_id"`
-	InstanceIDs []string `json:"instance_ids"`
+	ImageID      string   `json:"image_id"`
+	StagingDir   string   `json:"staging_dir"`
+	PayloadID    string   `json:"payload_id"`
+	InstanceIDs  []string `json:"instance_ids"`
+	BtcppVersion string   `json:"btcpp_version,omitempty"`
+	RosDistro    string   `json:"ros_distro,omitempty"`
 	// Deprecated: present only in old registry files; migrated to InstanceIDs on load.
 	InstanceID string `json:"instance_id,omitempty"`
 }
@@ -83,8 +85,8 @@ func Load(libPath string) (*Registry, error) {
 	return r, nil
 }
 
-// adds instanceID to the reference set for imageID; if the record does not yet exist, it is created with stagingDir/payloadID; if it exists, stagingDir and payloadID are left unchanged (the first extractor's values are canonical)
-func (r *Registry) RecordExtraction(imageID, stagingDir, payloadID, instanceID string) error {
+// adds instanceID to the reference set for imageID; if the record does not yet exist, it is created with stagingDir/payloadID/versions; if it exists, those fields are left unchanged (the first extractor's values are canonical)
+func (r *Registry) RecordExtraction(imageID, stagingDir, payloadID, instanceID, btcppVersion, rosDistro string) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	rec, exists := r.data.Extractions[imageID]
@@ -97,22 +99,23 @@ func (r *Registry) RecordExtraction(imageID, stagingDir, payloadID, instanceID s
 		return r.save()
 	}
 	r.data.Extractions[imageID] = ExtractionRecord{
-		ImageID:     imageID,
-		StagingDir:  stagingDir,
-		PayloadID:   payloadID,
-		InstanceIDs: []string{instanceID},
+		ImageID:      imageID,
+		StagingDir:   stagingDir,
+		PayloadID:    payloadID,
+		InstanceIDs:  []string{instanceID},
+		BtcppVersion: btcppVersion,
+		RosDistro:    rosDistro,
 	}
 	return r.save()
 }
 
-// returns a snapshot of all currently recorded imageID -> stagingDir mappings; this is a read-only query: executor injection consumes staging dirs but
-// does not hold a producer reference
-func (r *Registry) AllStagingDirs() map[string]string {
+// returns a snapshot of all currently recorded extraction records; read-only — injection does not hold a producer reference
+func (r *Registry) AllExtractions() map[string]ExtractionRecord {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	result := make(map[string]string, len(r.data.Extractions))
+	result := make(map[string]ExtractionRecord, len(r.data.Extractions))
 	for imageID, rec := range r.data.Extractions {
-		result[imageID] = rec.StagingDir
+		result[imageID] = rec
 	}
 	return result
 }


### PR DESCRIPTION
Various updates to support revised component standard:
- Profile information is now recovered by parsing image labels declared at build time.
- BT.CPP versions and ROS distros are also stored as labels within images, and the CLI will now refuse to inject dependencies in the case of mismatches between a skillset exporting dependencies and an executor importing them.
- Version of the CLI is now tracked internally and within image labels, and the CLI will refuse to launch images with versions that are incompatible with self (to control the above changes). 