### PR TITLE
inspect, generate, and version commands added and other updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,186 +13,287 @@
 </div>
 
 # Coral CLI
-Coral (COmpositional Robotics Abstraction Layer) represents an effort toward truly composable software for robotics applications. Coral draws inspiration from functional programming to create reconfigurable systems composed of modular and reusable atomic components with minimal functional interfaces. This is achieved using behavior trees and containerization.
+Coral (COmpositional Robotics Abstraction Layer) represents an effort toward truly compositional software for robotics applications. Coral draws inspiration from functional programming to create reconfigurable systems composed of modular and reusable atomic components with minimal functional interfaces. This is achieved using behavior trees and containerization.
 
 Just as coral reefs support tremendous biodiversity (25% of marine species while covering less than 1% of the sea floor), Coral provides the scaffolding necessary to support a rich ecosystem of robotics software that enables scalable solutions across a wide range of real-world applications.
 
-Users are referred to [coral_examples](https://github.com/swanbeck/coral_examples.git) for examples of practical applications enabled by Coral.
-
-<!-- The Coral CLI is designed to simplify working with Docker images that are compatible with the Coral ecosystem. It wraps the Docker CLI and extends it with several helpful commands.  -->
+Users are referred to the [Coral Examples](https://github.com/swanbeck/coral_examples.git) for examples of practical applications enabled by Coral.
 
 ---
 ### Building
 Before beginning, [install Go](https://go.dev/doc/install) on your system.
 
-The easiest way to build and install the Coral CLI on Linux is by using the included [MakeFile](./Makefile). Run
+The easiest way to build and install the Coral CLI on Linux is by using the included [Makefile](./Makefile). Run
 ```
 make install
 ```
-to build the binary, place it on your `PATH`, and generate and install shell completion scripts. You will need to run one of the printed commands based on your shell to enable autocompletion.
+to build the binary, place it at `/usr/local/bin/coral`, and generate and install shell completion scripts for bash, zsh, and fish. After installation, run one of the printed commands (or open a new terminal) to enable tab completion.
 
-Verify it can be found with
+Verify the installation with
 ```
-coral
-```
-which should print out
-```
-Coral provides and manages an ecosystem of compositional robotics software
-
-Usage:
-  coral [flags]
-  coral [command]
-
-Available Commands:
-  completion  Generate completion script
-  help        Help about any command
-  launch      Launches Coral instances
-  shutdown    Stops and cleans up Coral instances
-  tail        Tails the logs of running Coral instances
-  verify      Checks if a component is compliant with Coral's standards
-
-Flags:
-  -h, --help   help for coral
-
-Use "coral [command] --help" for more information about a command.
+coral version
 ```
 
 To uninstall, run
 ```
 make uninstall
 ```
-which will remove the installed binary and shell completion scripts.
 
 ---
-### Usage
-The Coral CLI wraps certain Docker commands, including `coral images` and `coral ps`, to only show Coral images or containers. However, most of its utility is realized through a small set of bespoke commands:
+### Component model
 
-#### Launch
-Coral launch takes in a valid Docker compose file and starts services listed within it in a particular manner. It first extracts runtime dependencies from all provided images using an embedded extraction entrypoint. To do this, the environment variable `CORAL_LIB`, which controls where extracted files are placed, must be set to an absolute path in the local filesystem. Additionally, if running Coral from inside a Docker container, the environment variable `CORAL_IS_DOCKER=true` must be set and `CORAL_HOST_LIB` must point to the same directory as `CORAL_LIB` but within the host filesystem. For example, consider the following Docker compose file snippet:
+A Coral component is a Docker image that carries one or more ROS2 packages and a set of metadata labels. The CLI uses these labels to orchestrate multi-component systems without any configuration beyond a standard Docker Compose file.
+
+#### Profiles
+
+Every Coral image must include a `coral.profile` label set to one of three values:
+
+| Profile | Role |
+|---------|------|
+| `drivers` | Hardware drivers and infrastructure services |
+| `skillsets` | Capability packages that export BehaviorTree.CPP plugins |
+| `executors` | BT.CPP executor containers that load plugins at runtime |
+
+#### Library export and import
+
+Skillsets (and drivers that expose behaviors) export their compiled shared libraries by:
+1. Placing `.so` files under a directory inside the image
+2. Setting `ENV CORAL_EXPORT_LIB=<that directory>`
+3. Ensuring the directory is world-readable: `RUN chmod o+rx <that directory>`
+
+At launch time the CLI copies these files out of every skillset/driver image and injects them into executor containers before starting them. Executors receive the libraries via the path set by their `CORAL_IMPORT_LIB` environment variable.
+
+Library injection is filtered for compatibility: only libraries whose `coral.btcpp_version` and `coral.ros_distro` labels match those of the target executor are injected. A warning is printed for any skipped payloads.
+
+#### Version compatibility
+
+The CLI checks that the major version in each image's `coral.version` label matches the CLI's own major version. Pass `--skip-version-check` to `coral launch` to bypass this check.
+
+---
+### Creating a New Component
+Refer to [coral_realsense](https://github.com/swanbeck/coral_realsense) and [coral_hyla_slam](https://github.com/swanbeck/coral_hyla_slam) for complete examples of a Coral `driver` and `skillset` component, respectively.
+Custom executors can be created, but the prebuilt [basic_executor](https://hub.docker.com/r/swanbeck/coral-basic_executor) (which dynamically loads behavior libraries and runs a single behavior tree to completion) will cover 99% of applications.
+
+The `coral generate` command can be used to generate a template skeleton for a new component. Further details are provided in the following section.
+
+To ensure proper software versioning and compatibility, components should extend one of the [Coral base images](https://hub.docker.com/u/swanbeck) hosted on Dockerhub.
+
+| Image | Description |
+|---------|------|
+| `coral-base` | Base image for all other Coral images, containing only ROS and simple utilities. Common starting point for `drivers`. |
+| `coral-btcpp` | Extends the base image with BehaviorTree.CPP. Common starting point for `skillsets` and `executors`. |
+| `coral-cuda` | Extends the btcpp image with CUDA support. Starting point for any GPU-accelerated `drivers` or `skillsets`. |
+
+Images are maintained for amd64 and arm64 architectures. The current image generation is v2.1.x, which are compatible with Coral CLI v2.x.x and are based on Ubuntu 22.04 with ROS2 Humble, BT.CPP 4.9.0, and CUDA 12.6.
+
+#### Jetson Support
+Because many libraries using the GPU must be built specially for Jetson devices, the base `coral-cuda` images are not Jetson-compatible
+For any components that are not GPU-accelerated, `coral-base` and `coral-btcpp` are valid base images.
+Special Jetson-compatible CUDA images have not yet been migrated to Coral v2.x.x, but will be hosted on Dockerhub in the near future.
+
+---
+### Commands
+
+#### `generate` — scaffold a new component
+
+`coral generate` creates a complete, ready-to-build skeleton for a new skillset component:
+
+```
+coral generate <name> [--output <dir>]
+```
+
+The name must be lowercase `snake_case`. The command creates a `coral_<name>/` directory containing:
+
+- A two-stage Dockerfile (runtime base + library export stage)
+- Three ROS2 packages under `src/<name>/`:
+  - `<name>_interfaces` — a custom service definition
+  - `<name>` — a ROS2 node that advertises that service
+  - `<name>_behaviors` — a BehaviorTree.CPP plugin that calls the service
+- `runtime/run.sh`, `runtime/run.launch.py`, and `runtime/default/params.yaml`
+- `compose.yaml` and `.env`
+
+The skeleton compiles and exports a working `Ping` behavior end-to-end. Every generated file contains `TODO` comments explaining what to replace. Build the result with:
+
+```
+cd coral_<name>
+docker compose build
+coral verify coral-<name>:v0.1.0
+```
+
+---
+
+#### `verify` — validate a component image
+
+`coral verify` checks whether a locally available image meets Coral's requirements:
+
+```
+coral verify <image>
+```
+
+The command checks:
+1. **`coral.profile` label** is present and set to `drivers`, `skillsets`, or `executors`
+2. **`CORAL_EXPORT_LIB`** — if set in the image environment:
+   - The directory exists and has world read+execute permissions (`o+rx`)
+   - The directory is non-empty
+3. **Behavior plugin** — if the profile is `skillsets`, at least one `lib*behaviors.so` must be present under `CORAL_EXPORT_LIB`
+
+A successful run prints a check for each step and ends with a success message:
+```
+[INFO] coral.profile="skillsets"
+[INFO] CORAL_EXPORT_LIB=/coral_lib permissions OK (0755)
+[INFO] CORAL_EXPORT_LIB=/coral_lib is populated (2 entries)
+[INFO] Found behavior lib(s): libmy_component_behaviors.so
+[SUCCESS] Image is compliant with Coral's standards
+```
+
+---
+
+#### `launch` — start a Coral instance
+
+`coral launch` starts a set of services described in a Docker Compose file in the correct order, handling library extraction and injection automatically.
+
+```
+coral launch [-f <compose.yaml>] [-g <group>] [--handle <handle>] [-d]
+```
+
+If `-f` is not provided, the CLI looks for `compose.yaml`, `docker-compose.yaml`, `compose.yml`, or `docker-compose.yml` in the current directory.
+
+**Launch sequence:**
+1. Validates that all images are present locally and have a valid `coral.profile` label
+2. Extracts shared libraries from every skillset and driver image into a staging directory
+3. Starts `drivers` and `skillsets` using `docker compose up`
+4. Waits for all drivers and skillsets with Docker health checks to report healthy (up to `--health-timeout` seconds, default 120)
+5. Creates executor containers, injects compatible libraries into each one, then starts them
+
+**Compose file format:**
+
+Each service needs only an `image:` field (and any runtime configuration). The CLI reads the `coral.profile` label from the image to determine start order — no `profiles:` key is needed in the compose file itself.
 
 ```yaml
 services:
-  coral_cli:
-    image: coral_cli-latest
+  my_slam:
+    image: my_organization/coral-my_slam:v1.0.0
+    network_mode: host
+    ipc: host
+
+  my_runner:
+    image: swanbeck/coral-basic_executor:v2.1.1
     environment:
-      - CORAL_LIB=/home/coral/lib
-      - CORAL_IS_DOCKER=true
-      - CORAL_HOST_LIB=/absolute/path/on/host/to/lib
-      - CORAL_UID=1001
-      - CORAL_GID=1001
-    volumes:
-      - /absolute/path/on/host/to/lib:/home/coral/lib
-```
-These variables must be set because Coral launches Docker containers using the host system's Docker installation. `CORAL_UID` and `CORAL_GID` can also be set to ensure proper ownership of extracted files when running Coral as a non-default user (1000:1000). 
-
-Once the proper environment variables are set, a Docker compose file can be created to start the relevant containers. The compose file to be run can be specified explicitly with `-f` or a local file `(docker-)compose.y(a)ml` will be used if it exists and is not explicitly overridden. As an example, here is a valid Docker compose file that is compatible with Coral launch:
-```yaml
-# compose.yaml
-x-coral-config:
-  &coral-config
-  environment:
-    - ROS_DOMAIN_ID=${INTERNAL_ROS_DOMAIN_ID}
-    - RMW_IMPLEMENTATION=${INTERNAL_RMW_IMPLEMENTATION}
-    - CYCLONEDDS_URI=${INTERNAL_CYCLONEDDS_URI}
-    - DYNAMIC_LIBRARY=${INTERNAL_DYNAMIC_LIBRARY}
-    - BT_FILE=${INTERNAL_BT_FILE}
-    - CONFIG_PATH=${INTERNAL_CONFIG_PATH}
-    - COMPOSE_TEMPLATE=${INTERNAL_COMPOSE_TEMPLATE}
-    - HOST_CONFIG_PATH=${HOST_CONFIG_PATH}
-    - CORAL_LIBRARY_PATH=${INTERNAL_DYNAMIC_LIBRARY}
-    - PARAMS=${INTERNAL_CONFIG_PATH}/params/main.yaml
-  volumes:
-    - ${HOST_CONFIG_PATH}:${INTERNAL_CONFIG_PATH}
-  network_mode: host
-  ipc: host
-  tty: true
-
-services:
-
-  llama:
-    image: coral-llama3.1_8b:humble-amd64
-    <<: *coral-config
-    environment:
-      - ROS_DOMAIN_ID=${INTERNAL_ROS_DOMAIN_ID}
-      - RMW_IMPLEMENTATION=${INTERNAL_RMW_IMPLEMENTATION}
-      - CYCLONEDDS_URI=${INTERNAL_CYCLONEDDS_URI}
-      - PARAMS=${INTERNAL_CONFIG_PATH}/params/main.yaml
-      - AGENT=llama
-    profiles: [skillsets]
-
-  whisper:
-    image: coral-whisper:humble-amd64
-    <<: *coral-config
-    environment:
-      - ROS_DOMAIN_ID=${INTERNAL_ROS_DOMAIN_ID}
-      - RMW_IMPLEMENTATION=${INTERNAL_RMW_IMPLEMENTATION}
-      - CYCLONEDDS_URI=${INTERNAL_CYCLONEDDS_URI}
-      - PARAMS=${INTERNAL_CONFIG_PATH}/params/main.yaml
-      - AGENT=whisper
-    profiles: [skillsets]
-
-  gtts:
-    image: coral-gtts:humble-amd64
-    <<: *coral-config
-    environment:
-      - ROS_DOMAIN_ID=${INTERNAL_ROS_DOMAIN_ID}
-      - RMW_IMPLEMENTATION=${INTERNAL_RMW_IMPLEMENTATION}
-      - CYCLONEDDS_URI=${INTERNAL_CYCLONEDDS_URI}
-      - PARAMS=${INTERNAL_CONFIG_PATH}/params/main.yaml
-      - AGENT=gtts
-    profiles: [skillsets]
-
-  dynamic_runner:
-    image: coral-dynamic_runner:humble-amd64
-    <<: *coral-config
-    profiles: [executors]
+      BT_FILE: /path/to/behavior_tree.xml
+    network_mode: host
+    ipc: host
 ```
 
-Importantly, Coral assumes that the provided compose file uses the `profiles` tag. Only the profiles `drivers`, `skillsets`, and `executors` are used by Coral; any other profiles used will be ignored. When running, `drivers` and `skillsets` are started first and `executors` are started a short time after. 
+**Key flags:**
 
-For example, running the command 
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-f, --compose-file` | auto-detect | Path to compose file |
+| `--env-file` | auto-detect | Path to `.env` file for variable substitution |
+| `-g, --group` | `coral` | Group label for this instance |
+| `--handle` | — | Optional unique handle |
+| `-d, --detached` | `false` | Run in background |
+| `--lib-dir` | `$CORAL_LIB` or `./lib` | Directory for extracted library staging |
+| `--executor-delay` | `0` | Additional seconds to wait after health check before starting executors |
+| `--health-timeout` | `120` | Seconds to wait for health checks to pass before starting executors |
+| `-p, --profile` | all | Launch only the specified profile(s) |
+| `--skip-version-check` | `false` | Skip `coral.version` major-version check |
+
+**Library staging directory:**
+
+The CLI resolves the staging path in this order: `--lib-dir` flag → `$CORAL_LIB` environment variable → `./lib` (created automatically). The directory holds staging subdirectories and a `registry.json` that reference-counts which instances hold each extracted library tree. Staging directories are removed automatically when the last instance that references them shuts down.
+
+**Running the CLI inside Docker:**
+
+When the CLI itself runs inside a container, Docker volume mounts in compose files use host paths that differ from container paths. Set these additional environment variables:
 
 ```
-coral launch
+CORAL_IS_DOCKER=true
+CORAL_HOST_LIB=/absolute/path/on/host/to/lib   # host-side path matching CORAL_LIB
 ```
-produces the following partial output:
 
+**Example output (detached):**
 ```
-[INFO] Launching new instance coral-d3db75df-a1ec-41ba-bad5-2f4169b38ce1
-[INFO] Starting skillsets (3): [llama whisper gtts]
-[+] Running 3/3
- ✔ Container coral-d3db75df-a1ec-41ba-bad5-2f4169b38ce1-whisper-1  Started
- ✔ Container coral-d3db75df-a1ec-41ba-bad5-2f4169b38ce1-llama-1    Started
- ✔ Container coral-d3db75df-a1ec-41ba-bad5-2f4169b38ce1-gtts-1     Started
-[INFO] Starting executors (1): [dynamic_runner]
+[INFO] Launching new instance coral-d3db75df
+[INFO] Starting skillsets (2): [my_slam my_other_skill]
+[+] Running 2/2
+ ✔ Container coral-d3db75df-my_slam-1          Started
+ ✔ Container coral-d3db75df-my_other_skill-1   Started
+[INFO] Waiting for drivers and skillsets to become healthy...
+[INFO] Starting executors (1): [my_runner]
+[INFO] Injected 3 libraries into executor my_runner
 [+] Running 1/1
- ✔ Container coral-d3db75df-a1ec-41ba-bad5-2f4169b38ce1-dynamic_runner-1  Started
- ...
+ ✔ Container coral-d3db75df-my_runner-1        Started
+```
+---
+
+#### `shutdown` — stop a Coral instance
+
+`coral shutdown` stops and cleans up instances launched with `coral launch`.
+
+```
+coral shutdown --name <name>
+coral shutdown --handle <handle>
+coral shutdown -g <group>
+coral shutdown -a
 ```
 
-When running with `coral launch`, it is often useful to assign a `-g` group or `--handle` to a running instance. Handles are meant to be unique for a single instance and groups allow you to control several instances together. These are especially useful when running in detached mode
+| Flag | Description |
+|------|-------------|
+| `-n, --name` | Stop the instance with this generated name |
+| `--handle` | Stop the instance with this handle |
+| `-g, --group` | Stop all instances in this group |
+| `-a, --all` | Stop all tracked instances |
+| `--kill` | Forcefully kill containers before removing (default: true) |
+
+Shutdown reads instance metadata stored in `~/.coral_cli/instances/`. Foreground instances (launched without `-d`) clean up their own metadata when they exit; only detached instances need an explicit `coral shutdown`.
+
+---
+
+#### `tail` — stream logs from running instances
+
+`coral tail` attaches to the logs of one or more running Coral instances, color-coding each container's output by service name.
+
 ```
-coral launch -g group1 -d
+coral tail -a
+coral tail -n <name> [-n <name2> ...]
+coral tail -g <group>
+coral tail --handle <handle>
 ```
 
-to enable easy shutdown.
+Press `Ctrl+C` to detach without stopping the instance.
 
-#### Shutdown
-Coral shutdown exists to nicely kill and clean up after Coral launch commands that are run in detached mode. For example, if a launch command is run
-```
-coral launch -g group1 -d
-```
-it can be nicely killed and cleaned up with
-```
-coral shutdown -g group1
-```
-Shutdown can also be controlled via an instance name that is generated and printed on Coral launch with `-n` (`coral-1747512980139421567` in the example output above) or using a `--handle` provided when Coral launch is run. The `-a` flag can also be used to shutdown all running Coral instances.
+---
 
-#### Verify
-When building a Coral component, it is useful to test whether it is compatible with the Coral CLI. To do this, you can use the command:
+#### `inspect` — display a component's behavior manifest
+
+`coral inspect` loads any behavior plugins from a component image and prints the registered BehaviorTree.CPP node types along with their ports and metadata.
+
 ```
-coral verify <IMAGE_NAME>:<IMAGE_TAG>
+coral inspect <image> [--format json|markdown] [-o <output-file>]
 ```
+
+The default format is markdown. Pass `--format json` for machine-readable output, or `-o <file>` to write to a file instead of stdout.
+
+> **Note:** Full behavior introspection requires `coral.version >= v2.1.1` within components.
+
+---
+
+#### `images` and `ps` — filtered Docker views
+
+`coral images` lists only Docker images whose repository name starts with `coral`:
+
+```
+coral images [<docker images flags>]
+```
+
+`coral ps` lists only running containers whose image starts with `coral`:
+
+```
+coral ps [<docker ps flags>]
+```
+
+All other Docker subcommands are passed through to Docker directly, e.g. `coral pull`, `coral rmi`.
 
 ---
 ### Citation

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -1,0 +1,902 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"coral_cli/internal/logging"
+)
+
+var generateOutputDir string
+
+func init() {
+	generateCmd.Flags().StringVarP(&generateOutputDir, "output", "o", ".", "Parent directory in which to create the component (default: current directory)")
+}
+
+var generateCmd = &cobra.Command{
+	Use:   "generate <name>",
+	Short: "Scaffold a new Coral skillset component",
+	Long: `Generates a complete skeleton for a Coral skillset component.
+
+The generated component includes:
+  - A multi-stage Dockerfile with build and export stages
+  - Three ROS2 packages: <name>_interfaces, <name>, and <name>_behaviors
+  - A working example: a Ping service on the node, called by a Ping behavior
+  - runtime/ with a launch file and default parameters
+  - compose.yaml and .env for building and running with Docker Compose
+
+The skeleton compiles and exports a single BehaviorTree.CPP plugin (.so) that
+calls the bundled node via a custom ROS2 service. Replace the Ping example with
+your own logic.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		name := args[0]
+		if err := validateComponentName(name); err != nil {
+			return err
+		}
+		if err := generateComponent(name, generateOutputDir); err != nil {
+			return fmt.Errorf("%s: %w", logging.Failure("generation failed"), err)
+		}
+		return nil
+	},
+}
+
+var namePattern = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
+
+func validateComponentName(name string) error {
+	if !namePattern.MatchString(name) {
+		return fmt.Errorf("name %q must be lowercase snake_case (start with a letter; letters, digits, and underscores only)", name)
+	}
+	return nil
+}
+
+// toPascalCase converts snake_case to PascalCase (e.g. my_component → MyComponent)
+func toPascalCase(s string) string {
+	parts := strings.Split(s, "_")
+	for i, p := range parts {
+		if len(p) > 0 {
+			parts[i] = strings.ToUpper(p[:1]) + p[1:]
+		}
+	}
+	return strings.Join(parts, "")
+}
+
+func writeGeneratedFile(path, content string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return fmt.Errorf("creating directory %s: %w", filepath.Dir(path), err)
+	}
+	return os.WriteFile(path, []byte(content), 0644)
+}
+
+func generateComponent(name, outputDir string) error {
+	root := filepath.Join(outputDir, "coral_"+name)
+	if _, err := os.Stat(root); err == nil {
+		return fmt.Errorf("directory %q already exists", root)
+	}
+
+	class := toPascalCase(name) // e.g. "my_component" → "MyComponent"
+	r := strings.NewReplacer(
+		"{{NAME}}", name,
+		"{{CLASS}}", class,
+	)
+
+	type genFile struct {
+		rel     string
+		content string
+		mode    os.FileMode
+	}
+
+	files := []genFile{
+		{".env", genEnv(), 0644},
+		{"compose.yaml", r.Replace(genComposeYAML()), 0644},
+		{"docker/Dockerfile", r.Replace(genDockerfile()), 0644},
+		{"docker/export/.keep", "", 0644},
+		{"runtime/run.sh", r.Replace(genRunSh()), 0755},
+		{"runtime/run.launch.py", r.Replace(genLaunchPy()), 0644},
+		{"runtime/default/params.yaml", r.Replace(genParamsYAML()), 0644},
+		// interfaces package
+		{"src/" + name + "/" + name + "_interfaces/CMakeLists.txt", r.Replace(genInterfacesCMake()), 0644},
+		{"src/" + name + "/" + name + "_interfaces/package.xml", r.Replace(genInterfacesPkgXML()), 0644},
+		{"src/" + name + "/" + name + "_interfaces/srv/Ping.srv", genPingSrv(), 0644},
+		// node package
+		{"src/" + name + "/" + name + "/CMakeLists.txt", r.Replace(genNodeCMake()), 0644},
+		{"src/" + name + "/" + name + "/package.xml", r.Replace(genNodePkgXML()), 0644},
+		{"src/" + name + "/" + name + "/include/" + name + "/" + name + "_node.hpp", r.Replace(genNodeHpp()), 0644},
+		{"src/" + name + "/" + name + "/src/" + name + "_node.cpp", r.Replace(genNodeCpp()), 0644},
+		// behaviors package
+		{"src/" + name + "/" + name + "_behaviors/CMakeLists.txt", r.Replace(genBehaviorsCMake()), 0644},
+		{"src/" + name + "/" + name + "_behaviors/package.xml", r.Replace(genBehaviorsPkgXML()), 0644},
+		{"src/" + name + "/" + name + "_behaviors/include/" + name + "_behaviors/ping.hpp", r.Replace(genPingHpp()), 0644},
+		{"src/" + name + "/" + name + "_behaviors/src/ping.cpp", r.Replace(genPingCpp()), 0644},
+		{"src/" + name + "/" + name + "_behaviors/src/plugin.cpp", r.Replace(genPluginCpp()), 0644},
+	}
+
+	for _, f := range files {
+		path := filepath.Join(root, f.rel)
+		if err := writeGeneratedFile(path, f.content); err != nil {
+			return fmt.Errorf("writing %s: %w", f.rel, err)
+		}
+		if f.mode != 0644 {
+			if err := os.Chmod(path, f.mode); err != nil {
+				return fmt.Errorf("chmod %s: %w", f.rel, err)
+			}
+		}
+	}
+
+	fmt.Println(logging.Success(fmt.Sprintf("Generated coral_%s/", name)))
+	fmt.Printf("\nNext steps:\n")
+	fmt.Printf("  cd coral_%s\n", name)
+	fmt.Printf("  docker compose build          # builds the image\n")
+	fmt.Printf("  coral verify coral-%s:{tag}  # checks the image is Coral-compliant\n\n", name)
+	fmt.Printf("The Ping example is a working end-to-end skeleton. Replace the service\n")
+	fmt.Printf("definition, node logic, and behavior with your own implementation.\n")
+	fmt.Printf("Search for TODO comments throughout the generated files for guidance.\n")
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Top-level files
+// ---------------------------------------------------------------------------
+
+func genEnv() string {
+	return `# TODO: Set BASE_VERSION to the coral-btcpp base image tag you want to build on.
+# Available tags: https://hub.docker.com/r/swanbeck/coral-btcpp/tags
+BASE_VERSION=v2.1.1
+
+# TODO: Set SELF_VERSION to the version tag for this component's image.
+SELF_VERSION=v2.1.0
+`
+}
+
+func genComposeYAML() string {
+	return `services:
+  {{NAME}}:
+    # TODO: Update the image name to match your Docker Hub username / registry.
+    image: coral-{{NAME}}:${SELF_VERSION}
+    build:
+      context: ./
+      dockerfile: docker/Dockerfile
+      platforms:
+        - linux/amd64
+        - linux/arm64
+      target: coral
+      args:
+        BASE_VERSION: ${BASE_VERSION}
+        SELF_VERSION: ${SELF_VERSION}
+    network_mode: host
+    ipc: host
+`
+}
+
+// ---------------------------------------------------------------------------
+// Dockerfile
+// ---------------------------------------------------------------------------
+
+func genDockerfile() string {
+	return `# This is a two-stage Dockerfile:
+#
+#  base  — builds and installs the ROS2 packages, sets up the runtime entrypoint.
+#          This is what runs on the robot (the "payload" container).
+#
+#  coral — extends base by compiling the packages again as shared libraries and
+#          copying the resulting .so files into /coral_lib. The Coral CLI copies
+#          these out at launch time so that executor containers can load them.
+#          It also sets CORAL_EXPORT_LIB and the coral.profile label so that
+#          'coral verify' can validate the image.
+
+ARG BASE_VERSION=unknown
+FROM swanbeck/coral-btcpp:${BASE_VERSION} AS base
+
+ARG SELF_VERSION=unknown
+LABEL org.opencontainers.image.title="Coral {{CLASS}}"
+LABEL org.opencontainers.image.version="${SELF_VERSION}"
+LABEL org.opencontainers.image.description="TODO: Add a description for your component."
+
+USER root
+
+# TODO: Install any additional apt packages your component needs.
+# RUN apt-get update && apt-get install -y \
+#     <your-package> \
+#     && rm -rf /var/lib/apt/lists/*
+
+COPY ./src/ /home/coral/ws/src/
+WORKDIR /home/coral/ws
+RUN ROS_DISTRO=$(basename /opt/ros/*) && \
+    . /opt/ros/${ROS_DISTRO}/setup.sh && \
+    colcon build --packages-up-to {{NAME}} && \
+    rm -rf build/ log/ src/
+
+COPY ./runtime /home/coral/runtime
+RUN chmod +x /home/coral/runtime/run.sh && \
+    chown -R coral:coral /home/coral/runtime
+
+USER coral
+RUN echo "source /home/coral/ws/install/local_setup.bash" >> ~/.bashrc && \
+    echo "PS1='\[\e[1;33m\][{{NAME}}]\[\e[0m\]\[\e[1;32m\]\u@\h\[\e[0m\]:\[\e[1;34m\]\w\[\e[0m\]\$ '" >> ~/.bashrc
+
+ENTRYPOINT [ "/home/coral/runtime/run.sh" ]
+
+# ---- export stage ----
+FROM base AS coral
+USER root
+
+# Create the export directory and populate it from a fresh build.
+COPY ./docker/export /coral_lib
+RUN mkdir -p /coral_lib/behaviors /coral_lib/interfaces
+
+WORKDIR /home/coral/export_ws
+COPY ./src ./src
+RUN ROS_DISTRO=$(basename /opt/ros/*) && \
+    . /opt/ros/${ROS_DISTRO}/setup.sh && \
+    colcon build --packages-up-to {{NAME}}_behaviors --cmake-args -DBUILD_SHARED_LIBS=ON && \
+    cp -r install/{{NAME}}_behaviors/lib/* /coral_lib/behaviors/ && \
+    cp -r install/{{NAME}}_interfaces/lib/* /coral_lib/interfaces/ && \
+    rm -rf /home/coral/export_ws
+
+# CRITICAL: world read+execute on /coral_lib so the CLI can copy from it,
+# and set CORAL_EXPORT_LIB so 'coral verify' knows where to look.
+RUN chmod o+rx /coral_lib
+ENV CORAL_EXPORT_LIB=/coral_lib
+LABEL coral.profile="skillsets"
+
+WORKDIR /home/coral/runtime
+USER coral
+`
+}
+
+// ---------------------------------------------------------------------------
+// Runtime files
+// ---------------------------------------------------------------------------
+
+func genRunSh() string {
+	return `#!/bin/bash
+set -e
+
+ROS_DISTRO=$(ls /opt/ros)
+. /opt/ros/${ROS_DISTRO}/setup.bash
+. /home/coral/ws/install/local_setup.bash
+
+ros2 launch /home/coral/runtime/run.launch.py
+
+exec "$@"
+`
+}
+
+func genLaunchPy() string {
+	return `#!/usr/bin/env python3
+import os
+from launch import LaunchDescription
+from launch.actions import (
+    DeclareLaunchArgument,
+    GroupAction,
+    OpaqueFunction,
+    RegisterEventHandler,
+    EmitEvent,
+)
+from launch.event_handlers import OnProcessExit
+from launch.events import Shutdown
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node, PushRosNamespace
+
+
+def launch_setup(context, *args, **kwargs):
+    agent = LaunchConfiguration("agent").perform(context)
+    params = LaunchConfiguration("params").perform(context)
+    log_level = LaunchConfiguration("log_level").perform(context)
+
+    # TODO: Add additional nodes here if your component needs them.
+    {{NAME}}_node = Node(
+        package="{{NAME}}",
+        executable="{{NAME}}_node",
+        parameters=[params],
+        arguments=["--ros-args", "--log-level", log_level],
+        output="screen",
+        emulate_tty=True,
+    )
+
+    actions = [{{NAME}}_node]
+
+    if agent != "":
+        actions.insert(0, PushRosNamespace(agent))
+
+    return [
+        GroupAction(actions),
+        RegisterEventHandler(
+            event_handler=OnProcessExit(
+                target_action={{NAME}}_node,
+                on_exit=[EmitEvent(event=Shutdown())],
+            )
+        ),
+    ]
+
+
+def generate_launch_description():
+    return LaunchDescription(
+        [
+            DeclareLaunchArgument(
+                "agent",
+                default_value=f'{os.getenv("AGENT", "")}',
+                description="Namespace applied to all processes. Set via the AGENT env var or launch argument.",
+            ),
+            DeclareLaunchArgument(
+                "params",
+                default_value=f'{os.getenv("PARAMS", "/home/coral/runtime/default/params.yaml")}',
+                description="Path to the ROS2 parameters file.",
+            ),
+            DeclareLaunchArgument(
+                "log_level",
+                default_value=f'{os.getenv("LOG_LEVEL", "INFO")}',
+                description="Log level for all processes.",
+            ),
+            OpaqueFunction(function=launch_setup),
+        ]
+    )
+`
+}
+
+func genParamsYAML() string {
+	return `# Default ROS2 parameters for the {{NAME}} component.
+# This file is loaded by run.launch.py at startup.
+# Override it at runtime by setting the PARAMS environment variable in compose.yaml.
+#
+# Parameter paths follow the pattern:
+#   /**:           applies to all nodes in all namespaces
+#     <node_name>:
+#       ros__parameters:
+#         <key>: <value>
+
+/**:
+  {{NAME}}_node:
+    ros__parameters:
+      # TODO: Replace 'prefix' with the parameters your node actually needs.
+      # The Ping service prepends this string to every reply ("Pong: <message>").
+      prefix: "Pong"
+`
+}
+
+// ---------------------------------------------------------------------------
+// {{NAME}}_interfaces package
+// ---------------------------------------------------------------------------
+
+func genInterfacesCMake() string {
+	return `cmake_minimum_required(VERSION 3.8)
+project({{NAME}}_interfaces)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+
+# TODO: Add additional .msg or .srv files here as your interface grows.
+set(srv_files
+  "srv/Ping.srv"
+)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  ${srv_files}
+)
+
+ament_export_dependencies(rosidl_default_runtime)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  set(ament_cmake_copyright_FOUND TRUE)
+  set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()
+`
+}
+
+func genInterfacesPkgXML() string {
+	return `<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>{{NAME}}_interfaces</name>
+  <version>0.0.0</version>
+  <!-- TODO: Add a description for the interface package. -->
+  <description>Custom ROS2 interfaces for the {{NAME}} component.</description>
+  <maintainer email="todo@example.com">TODO</maintainer>
+  <license>TODO</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+
+  <exec_depend>rosidl_default_runtime</exec_depend>
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>
+`
+}
+
+func genPingSrv() string {
+	return `# TODO: Replace this service definition with one that fits your component.
+#
+# The {{NAME}} node advertises this service on ~/ping, which resolves to
+# /{{NAME}}_node/ping (or /<agent>/{{NAME}}_node/ping when namespaced).
+# The Ping behavior calls this service and exposes the reply as a BT output port.
+
+# Request
+string message
+
+---
+
+# Response
+bool success
+string reply
+`
+}
+
+// ---------------------------------------------------------------------------
+// {{NAME}} node package
+// ---------------------------------------------------------------------------
+
+func genNodeCMake() string {
+	return `cmake_minimum_required(VERSION 3.8)
+project({{NAME}})
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+set(CMAKE_CXX_STANDARD 20)
+
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package({{NAME}}_interfaces REQUIRED)
+
+# TODO: Add find_package() calls for any additional ROS2 packages your node uses.
+
+include_directories(include)
+
+add_executable({{NAME}}_node
+  src/{{NAME}}_node.cpp
+)
+
+ament_target_dependencies({{NAME}}_node
+  rclcpp
+  {{NAME}}_interfaces
+  # TODO: Add additional ament dependencies here.
+)
+
+install(TARGETS {{NAME}}_node
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  set(ament_cmake_copyright_FOUND TRUE)
+  set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()
+`
+}
+
+func genNodePkgXML() string {
+	return `<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>{{NAME}}</name>
+  <version>0.0.0</version>
+  <!-- TODO: Add a description for the node package. -->
+  <description>ROS2 node package for the {{NAME}} component.</description>
+  <maintainer email="todo@example.com">TODO</maintainer>
+  <license>TODO</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>{{NAME}}_interfaces</depend>
+  <!-- TODO: Add additional <depend> entries for packages your node uses. -->
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>
+`
+}
+
+func genNodeHpp() string {
+	return `#pragma once
+
+#include <string>
+#include <rclcpp/rclcpp.hpp>
+#include "{{NAME}}_interfaces/srv/ping.hpp"
+
+// TODO: Add additional #includes for any message/service types your node uses.
+
+namespace {{NAME}} {
+
+/**
+ * {{CLASS}}Node — the main ROS2 node for the {{NAME}} component.
+ *
+ * It advertises a single Ping service (~/ping) that echoes back the request
+ * message prefixed with a configurable string. Replace this with whatever
+ * your component actually needs to do.
+ */
+class {{CLASS}}Node : public rclcpp::Node
+{
+public:
+    explicit {{CLASS}}Node(const rclcpp::NodeOptions & opts);
+
+private:
+    void handlePing(
+        const std::shared_ptr<{{NAME}}_interfaces::srv::Ping::Request> req,
+        std::shared_ptr<{{NAME}}_interfaces::srv::Ping::Response> res);
+
+    // TODO: Add member variables for subscriptions, publishers, timers, etc.
+    rclcpp::Service<{{NAME}}_interfaces::srv::Ping>::SharedPtr ping_service_;
+    std::string prefix_;
+};
+
+}  // namespace {{NAME}}
+`
+}
+
+func genNodeCpp() string {
+	return `#include "{{NAME}}/{{NAME}}_node.hpp"
+
+namespace {{NAME}} {
+
+{{CLASS}}Node::{{CLASS}}Node(const rclcpp::NodeOptions & opts)
+: rclcpp::Node("{{NAME}}_node", opts)
+{
+    // TODO: Replace the 'prefix' parameter with parameters your node actually needs.
+    // declare_parameter<T>(name, default) is the simplest way to expose parameters.
+    // For larger parameter sets consider using the generate_parameter_library package.
+    prefix_ = this->declare_parameter<std::string>("prefix", "Pong");
+
+    // Advertise the Ping service.
+    // ~/ping resolves to /{{NAME}}_node/ping (or /<agent>/{{NAME}}_node/ping when namespaced).
+    ping_service_ = this->create_service<{{NAME}}_interfaces::srv::Ping>(
+        "~/ping",
+        std::bind(&{{CLASS}}Node::handlePing, this,
+                  std::placeholders::_1, std::placeholders::_2));
+
+    RCLCPP_INFO(this->get_logger(),
+        "{{CLASS}}Node started. Prefix: '%s'", prefix_.c_str());
+
+    // TODO: Create subscriptions, publishers, timers, action servers, etc. here.
+}
+
+void {{CLASS}}Node::handlePing(
+    const std::shared_ptr<{{NAME}}_interfaces::srv::Ping::Request> req,
+    std::shared_ptr<{{NAME}}_interfaces::srv::Ping::Response> res)
+{
+    // TODO: Replace with the actual logic your service needs to perform.
+    res->reply   = prefix_ + ": " + req->message;
+    res->success = true;
+
+    RCLCPP_INFO(this->get_logger(),
+        "Ping received: '%s'  ->  '%s'",
+        req->message.c_str(), res->reply.c_str());
+}
+
+}  // namespace {{NAME}}
+
+int main(int argc, char ** argv)
+{
+    rclcpp::init(argc, argv);
+    auto node = std::make_shared<{{NAME}}::{{CLASS}}Node>(rclcpp::NodeOptions());
+    rclcpp::spin(node);
+    rclcpp::shutdown();
+    return 0;
+}
+`
+}
+
+// ---------------------------------------------------------------------------
+// {{NAME}}_behaviors package
+// ---------------------------------------------------------------------------
+
+func genBehaviorsCMake() string {
+	return `cmake_minimum_required(VERSION 3.8)
+project({{NAME}}_behaviors)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+set(CMAKE_CXX_STANDARD 20)
+
+# BUILD_SHARED_LIBS is OFF by default (static build used during the base stage).
+# The Dockerfile's export stage passes -DBUILD_SHARED_LIBS=ON to produce the
+# .so plugin that the Coral CLI copies into /coral_lib/behaviors/.
+option(BUILD_SHARED_LIBS "Build shared libraries instead of static" OFF)
+
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(behaviortree_cpp REQUIRED)
+find_package({{NAME}}_interfaces REQUIRED)
+
+# TODO: Add find_package() calls for any additional dependencies your behaviors need.
+
+include_directories(include)
+
+set(BEHAVIOR_DEPS
+  rclcpp
+  behaviortree_cpp
+  {{NAME}}_interfaces
+  # TODO: Add additional ament dependencies here.
+)
+
+set(LIBRARY_TYPE STATIC)
+if(BUILD_SHARED_LIBS)
+  set(LIBRARY_TYPE SHARED)
+endif()
+
+# TODO: Add additional source files here as you implement more behaviors.
+add_library({{NAME}}_behaviors ${LIBRARY_TYPE}
+  src/ping.cpp
+  src/plugin.cpp
+)
+target_compile_definitions({{NAME}}_behaviors PRIVATE BUILD_${LIBRARY_TYPE}_LIBRARY)
+ament_target_dependencies({{NAME}}_behaviors ${BEHAVIOR_DEPS})
+
+ament_export_targets(${PROJECT_NAME}Targets HAS_LIBRARY_TARGET)
+ament_export_dependencies(${BEHAVIOR_DEPS})
+
+install(
+  DIRECTORY include/
+  DESTINATION include
+)
+
+install(
+  TARGETS ${PROJECT_NAME}
+  EXPORT ${PROJECT_NAME}Targets
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+  RUNTIME DESTINATION bin
+  INCLUDES DESTINATION include
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  set(ament_cmake_copyright_FOUND TRUE)
+  set(ament_cmake_cpplint_FOUND TRUE)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package()
+`
+}
+
+func genBehaviorsPkgXML() string {
+	return `<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>{{NAME}}_behaviors</name>
+  <version>0.0.0</version>
+  <!-- TODO: Add a description for the behaviors package. -->
+  <description>BehaviorTree.CPP plugin package for the {{NAME}} component.</description>
+  <maintainer email="todo@example.com">TODO</maintainer>
+  <license>TODO</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>behaviortree_cpp</depend>
+  <depend>{{NAME}}_interfaces</depend>
+  <!-- TODO: Add additional <depend> entries for packages your behaviors use. -->
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>
+`
+}
+
+func genPingHpp() string {
+	return `#pragma once
+
+// TODO: Rename this file and class to something meaningful for your component.
+//
+// This is a BehaviorTree.CPP StatefulActionNode. The three lifecycle methods are:
+//   onStart()   — called once when the node is ticked for the first time
+//   onRunning() — called on every subsequent tick while the node returns RUNNING
+//   onHalted()  — called if the tree is halted before the node finishes
+//
+// Use StatefulActionNode for anything asynchronous (service calls, actions, timers).
+// Use SyncActionNode for simple synchronous work that completes in a single tick.
+
+#include <memory>
+#include <optional>
+#include <rclcpp/rclcpp.hpp>
+#include <behaviortree_cpp/action_node.h>
+#include "{{NAME}}_interfaces/srv/ping.hpp"
+
+namespace {{NAME}}_behaviors {
+
+class Ping : public BT::StatefulActionNode
+{
+public:
+    using PingSrv = {{NAME}}_interfaces::srv::Ping;
+
+    Ping(const std::string & name, const BT::NodeConfig & config);
+
+    // Declare the input and output ports that this node exposes to the behavior tree.
+    // Ports are the typed, named "wires" that connect nodes through the blackboard.
+    static BT::PortsList providedPorts();
+
+    BT::NodeStatus onStart() override;
+    BT::NodeStatus onRunning() override;
+    void           onHalted() override;
+
+private:
+    // Each behavior node creates its own rclcpp::Node for service/action clients.
+    // This keeps nodes decoupled and avoids callback executor conflicts.
+    std::shared_ptr<rclcpp::Node>                            node_;
+    rclcpp::Client<PingSrv>::SharedPtr                       client_;
+    std::optional<rclcpp::Client<PingSrv>::FutureAndRequestId> future_;
+    rclcpp::Time                                             stamp_;
+    int                                                      timeout_;
+};
+
+}  // namespace {{NAME}}_behaviors
+`
+}
+
+func genPingCpp() string {
+	return `#include "{{NAME}}_behaviors/ping.hpp"
+
+// TODO: Replace this behavior with one that matches your component's service.
+//
+// The full call chain is:
+//   BT executor ticks Ping::onStart()
+//     → creates a service client and sends an async request to {{NAME}}_node/ping
+//     → returns RUNNING immediately (non-blocking)
+//   BT executor ticks Ping::onRunning() each cycle
+//     → spins the future for up to 5 ms
+//     → returns RUNNING until the response arrives or the timeout expires
+//   On success: writes the reply to the 'reply' output port and returns SUCCESS
+//   On failure / timeout: returns FAILURE
+
+namespace {{NAME}}_behaviors {
+
+Ping::Ping(const std::string & name, const BT::NodeConfig & config)
+: BT::StatefulActionNode(name, config),
+  // Each behavior node owns its own rclcpp::Node. The node name matches the BT
+  // node name so it appears meaningfully in 'ros2 node list'.
+  node_(rclcpp::Node::make_shared(name))
+{}
+
+BT::PortsList Ping::providedPorts()
+{
+    // TODO: Replace these ports with the inputs and outputs your behavior needs.
+    return {
+        // InputPort<T>(key, default, description) — reads from the BT blackboard.
+        BT::InputPort<std::string>(
+            "agent", "",
+            "Namespace of the agent running {{NAME}}. "
+            "Leave empty to call in the local namespace."),
+        BT::InputPort<std::string>(
+            "message", "hello",
+            "Message to send to the Ping service."),
+        BT::InputPort<int>(
+            "timeout", 5,
+            "Maximum seconds to wait for the service response before returning FAILURE."),
+        // OutputPort<T>(key, description) — writes to the BT blackboard.
+        BT::OutputPort<std::string>(
+            "reply",
+            "Reply string returned by the Ping service."),
+    };
+}
+
+BT::NodeStatus Ping::onStart()
+{
+    // Build the service path.
+    // ~/ping on the node resolves to /{{NAME}}_node/ping (absolute).
+    // When the component runs under an agent namespace the full path becomes
+    // /<agent>/{{NAME}}_node/ping.
+    const std::string service_handle{"{{NAME}}_node/ping"};
+
+    auto agent = getInput<std::string>("agent");
+    if (agent.has_value() && !agent->empty()) {
+        client_ = node_->create_client<PingSrv>("/" + agent.value() + "/" + service_handle);
+    } else {
+        client_ = node_->create_client<PingSrv>(service_handle);
+    }
+
+    auto req     = std::make_shared<PingSrv::Request>();
+    req->message = getInput<std::string>("message").value_or("hello");
+    timeout_     = getInput<int>("timeout").value_or(5);
+
+    future_ = client_->async_send_request(req);
+    stamp_  = node_->now();
+
+    return BT::NodeStatus::RUNNING;
+}
+
+BT::NodeStatus Ping::onRunning()
+{
+    if (!future_.has_value()) {
+        RCLCPP_ERROR(node_->get_logger(),
+            "Ping::onRunning called without an active future — this should never happen.");
+        return BT::NodeStatus::FAILURE;
+    }
+
+    // Poll the future for up to 5 ms so the BT executor stays responsive.
+    auto status = rclcpp::spin_until_future_complete(
+        node_->get_node_base_interface(), future_.value(),
+        std::chrono::milliseconds(5));
+
+    switch (status) {
+        case rclcpp::FutureReturnCode::TIMEOUT: {
+            const rclcpp::Duration elapsed = node_->now() - stamp_;
+            if (elapsed > rclcpp::Duration(std::chrono::seconds(timeout_))) {
+                RCLCPP_ERROR(node_->get_logger(),
+                    "Ping timed out after %d second(s).", timeout_);
+                client_->remove_pending_request(future_.value());
+                return BT::NodeStatus::FAILURE;
+            }
+            return BT::NodeStatus::RUNNING;
+        }
+        case rclcpp::FutureReturnCode::INTERRUPTED:
+            RCLCPP_ERROR(node_->get_logger(), "Ping request was interrupted.");
+            return BT::NodeStatus::FAILURE;
+
+        case rclcpp::FutureReturnCode::SUCCESS: {
+            auto resp = future_->get();
+            setOutput<std::string>("reply", resp->reply);
+            RCLCPP_INFO(node_->get_logger(),
+                "Ping complete. Reply: '%s'", resp->reply.c_str());
+            return resp->success ? BT::NodeStatus::SUCCESS : BT::NodeStatus::FAILURE;
+        }
+    }
+    return BT::NodeStatus::FAILURE;
+}
+
+void Ping::onHalted()
+{
+    if (future_.has_value()) {
+        client_->remove_pending_request(future_.value());
+    }
+}
+
+}  // namespace {{NAME}}_behaviors
+`
+}
+
+func genPluginCpp() string {
+	return `#include <behaviortree_cpp/bt_factory.h>
+#include "{{NAME}}_behaviors/ping.hpp"
+
+// TODO: Register additional behavior nodes here as you add them.
+//
+// BT_RegisterNodesFromPlugin is the required entry point for BehaviorTree.CPP
+// shared library plugins. The Coral executor calls this when it loads the .so.
+
+extern "C" void BT_RegisterNodesFromPlugin(BT::BehaviorTreeFactory & factory)
+{
+    factory.registerNodeType<{{NAME}}_behaviors::Ping>("Ping");
+
+    // Metadata appears in the BT.CPP Groot visualizer and in 'coral inspect'.
+    factory.addMetadataToManifest("Ping", {
+        // TODO: Update the description to reflect what your component does.
+        {"description", "Calls the {{NAME}} Ping service and returns the reply."},
+    });
+}
+`
+}

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -2,9 +2,11 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"syscall"
 
@@ -73,6 +75,15 @@ func inspectImage(image, format, outputFile string) error {
 		return fmt.Errorf("reading image labels for %s: %w", image, err)
 	}
 
+	coralVersion, ok := allLabels["coral.version"]
+	if !ok || coralVersion == "" {
+		return fmt.Errorf("image %s does not set coral.version", image)
+	}
+	if !coralVersionAtLeast(coralVersion, 2, 1, 1) {
+		fmt.Println(logging.Warning(fmt.Sprintf(
+			"image coral.version %s predates v2.1.1; some inspection features may be unavailable", coralVersion)))
+	}
+
 	meta := inspect.ImageMetadata{
 		OCI:    make(map[string]string),
 		Labels: make(map[string]string),
@@ -87,22 +98,7 @@ func inspectImage(image, format, outputFile string) error {
 		}
 	}
 
-	runCmd := exec.Command("docker", "run", "--rm", "--entrypoint", "/ros_entrypoint.sh", image,
-		"bash", "-c", "LD_LIBRARY_PATH=${CORAL_EXPORT_LIB}/interfaces:${LD_LIBRARY_PATH} coral-inspect")
-	runCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-	runCmd.Stderr = os.Stderr
-
-	var stdout bytes.Buffer
-	runCmd.Stdout = &stdout
-
-	if err := runCmd.Run(); err != nil {
-		return fmt.Errorf("running coral-inspect on %s: %w", image, err)
-	}
-
-	behaviors, err := inspect.ParseBehaviors(stdout.Bytes())
-	if err != nil {
-		return fmt.Errorf("parsing output from %s: %w", image, err)
-	}
+	behaviors := extractBehaviors(image)
 
 	var out []byte
 	switch format {
@@ -126,4 +122,52 @@ func inspectImage(image, format, outputFile string) error {
 
 	_, err = os.Stdout.Write(out)
 	return err
+}
+
+// extractBehaviors runs coral-inspect inside the image and returns the parsed behavior map
+func extractBehaviors(image string) map[string]json.RawMessage {
+	runCmd := exec.Command("docker", "run", "--rm", "--entrypoint", "/ros_entrypoint.sh", image,
+		"bash", "-c", "LD_LIBRARY_PATH=${CORAL_EXPORT_LIB}/interfaces:${LD_LIBRARY_PATH} coral-inspect")
+	runCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	runCmd.Stderr = os.Stderr
+
+	var stdout bytes.Buffer
+	runCmd.Stdout = &stdout
+
+	if err := runCmd.Run(); err != nil {
+		fmt.Println(logging.Warning(fmt.Sprintf("behavior extraction unavailable for this image: %v", err)))
+		return map[string]json.RawMessage{}
+	}
+
+	behaviors, err := inspect.ParseBehaviors(stdout.Bytes())
+	if err != nil {
+		fmt.Println(logging.Warning(fmt.Sprintf("could not parse behavior output: %v", err)))
+		return map[string]json.RawMessage{}
+	}
+
+	return behaviors
+}
+
+// coralVersionAtLeast reports whether v (e.g. "v2.1.1" or "2.1.1") is >= major.minor.patch.
+func coralVersionAtLeast(v string, major, minor, patch int) bool {
+	v = strings.TrimPrefix(v, "v")
+	parts := strings.SplitN(v, ".", 3)
+	if len(parts) < 3 {
+		return false
+	}
+	nums := make([]int, 3)
+	for i, p := range parts {
+		n, err := strconv.Atoi(p)
+		if err != nil {
+			return false
+		}
+		nums[i] = n
+	}
+	if nums[0] != major {
+		return nums[0] > major
+	}
+	if nums[1] != minor {
+		return nums[1] > minor
+	}
+	return nums[2] >= patch
 }

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"coral_cli/internal/inspect"
+	"coral_cli/internal/libs"
 	"coral_cli/internal/logging"
 )
 
@@ -67,6 +68,25 @@ var inspectCmd = &cobra.Command{
 func inspectImage(image, format, outputFile string) error {
 	fmt.Println(logging.Info(fmt.Sprintf("Inspecting %s...", logging.BoldMagenta(image))))
 
+	allLabels, err := libs.GetImageLabels(image)
+	if err != nil {
+		return fmt.Errorf("reading image labels for %s: %w", image, err)
+	}
+
+	meta := inspect.ImageMetadata{
+		OCI:    make(map[string]string),
+		Labels: make(map[string]string),
+	}
+	const ociPrefix = "org.opencontainers.image."
+	for k, v := range allLabels {
+		switch {
+		case strings.HasPrefix(k, ociPrefix):
+			meta.OCI[strings.TrimPrefix(k, ociPrefix)] = v
+		case strings.HasPrefix(k, "coral."):
+			meta.Labels[k] = v
+		}
+	}
+
 	runCmd := exec.Command("docker", "run", "--rm", "--entrypoint", "/ros_entrypoint.sh", image,
 		"bash", "-c", "LD_LIBRARY_PATH=${CORAL_EXPORT_LIB}/interfaces:${LD_LIBRARY_PATH} coral-inspect")
 	runCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
@@ -87,13 +107,13 @@ func inspectImage(image, format, outputFile string) error {
 	var out []byte
 	switch format {
 	case "json":
-		out, err = inspect.FormatJSON(image, behaviors)
+		out, err = inspect.FormatJSON(image, meta, behaviors)
 		if err != nil {
 			return fmt.Errorf("formatting JSON: %w", err)
 		}
 		out = append(out, '\n')
 	case "markdown":
-		out = []byte(inspect.FormatMarkdown(image, behaviors))
+		out = []byte(inspect.FormatMarkdown(image, meta, behaviors))
 	}
 
 	if outputFile != "" {

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -1,0 +1,109 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+
+	"github.com/spf13/cobra"
+
+	"coral_cli/internal/inspect"
+	"coral_cli/internal/logging"
+)
+
+var (
+	inspectFormat string
+	inspectOutput string
+)
+
+func init() {
+	inspectCmd.Flags().StringVar(&inspectFormat, "format", "markdown", "Output format: json or markdown")
+	inspectCmd.Flags().StringVarP(&inspectOutput, "output", "o", "", "Write output to a file instead of stdout")
+
+	inspectCmd.RegisterFlagCompletionFunc("format", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		options := []string{"json", "markdown"}
+		var matches []string
+		for _, o := range options {
+			if strings.HasPrefix(o, toComplete) {
+				matches = append(matches, o)
+			}
+		}
+		return matches, cobra.ShellCompDirectiveNoFileComp
+	})
+
+	inspectCmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) > 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		out, err := exec.Command("docker", "images", "--format", "{{.Repository}}:{{.Tag}}").Output()
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+		var matches []string
+		for _, image := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+			if strings.HasPrefix(image, toComplete) {
+				matches = append(matches, image)
+			}
+		}
+		return matches, cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+var inspectCmd = &cobra.Command{
+	Use:   "inspect <image>",
+	Short: "Displays the behavior manifest exported by a component image",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if inspectFormat != "json" && inspectFormat != "markdown" {
+			return fmt.Errorf("--format must be json or markdown, got %q", inspectFormat)
+		}
+		return inspectImage(args[0], inspectFormat, inspectOutput)
+	},
+}
+
+func inspectImage(image, format, outputFile string) error {
+	fmt.Println(logging.Info(fmt.Sprintf("Inspecting %s...", logging.BoldMagenta(image))))
+
+	runCmd := exec.Command("docker", "run", "--rm", "--entrypoint", "/ros_entrypoint.sh", image,
+		"bash", "-c", "LD_LIBRARY_PATH=${CORAL_EXPORT_LIB}/interfaces:${LD_LIBRARY_PATH} coral-inspect")
+	runCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	runCmd.Stderr = os.Stderr
+
+	var stdout bytes.Buffer
+	runCmd.Stdout = &stdout
+
+	if err := runCmd.Run(); err != nil {
+		return fmt.Errorf("running coral-inspect on %s: %w", image, err)
+	}
+
+	behaviors, err := inspect.ParseBehaviors(stdout.Bytes())
+	if err != nil {
+		return fmt.Errorf("parsing output from %s: %w", image, err)
+	}
+
+	var out []byte
+	switch format {
+	case "json":
+		out, err = inspect.FormatJSON(image, behaviors)
+		if err != nil {
+			return fmt.Errorf("formatting JSON: %w", err)
+		}
+		out = append(out, '\n')
+	case "markdown":
+		out = []byte(inspect.FormatMarkdown(image, behaviors))
+	}
+
+	if outputFile != "" {
+		if err := os.WriteFile(outputFile, out, 0644); err != nil {
+			return fmt.Errorf("writing to %s: %w", outputFile, err)
+		}
+		fmt.Println(logging.Success(fmt.Sprintf("Written to %s", outputFile)))
+		return nil
+	}
+
+	_, err = os.Stdout.Write(out)
+	return err
+}

--- a/cmd/launch.go
+++ b/cmd/launch.go
@@ -29,15 +29,15 @@ import (
 )
 
 var (
-	launchComposePath   string
-	launchEnvFile       string
-	launchHandle        string
-	launchGroup         string
-	launchDetached      bool
-	launchKill          bool
-	launchExecutorDelay float32
-	launchProfiles      []string
-	launchLibDir        string
+	launchComposePath      string
+	launchEnvFile          string
+	launchHandle           string
+	launchGroup            string
+	launchDetached         bool
+	launchKill             bool
+	launchExecutorDelay    float32
+	launchProfiles         []string
+	launchLibDir           string
 	launchHealthTimeout    float32
 	launchSkipVersionCheck bool
 )

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -62,6 +62,7 @@ func runDockerCommand(args ...string) error {
 func init() {
 	// commands that do not overload docker commands belong here
 	rootCmd.AddCommand(completionCmd)
+	rootCmd.AddCommand(inspectCmd)
 	rootCmd.AddCommand(launchCmd)
 	rootCmd.AddCommand(shutdownCmd)
 	rootCmd.AddCommand(tailCmd)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -62,6 +62,7 @@ func runDockerCommand(args ...string) error {
 func init() {
 	// commands that do not overload docker commands belong here
 	rootCmd.AddCommand(completionCmd)
+	rootCmd.AddCommand(generateCmd)
 	rootCmd.AddCommand(inspectCmd)
 	rootCmd.AddCommand(launchCmd)
 	rootCmd.AddCommand(shutdownCmd)

--- a/cmd/verify.go
+++ b/cmd/verify.go
@@ -1,20 +1,23 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
+	"syscall"
 
+	"github.com/google/uuid"
 	"github.com/spf13/cobra"
 
 	"coral_cli/internal/libs"
 	"coral_cli/internal/logging"
 )
 
-var (
-	verifyLibDir string
-)
+var verifyLibDir string
 
 func init() {
 	verifyCmd.Flags().StringVar(&verifyLibDir, "lib-dir", "", "Directory to use for staging during verification (defaults to a temp dir)")
@@ -57,21 +60,132 @@ func verify(imageName string, libDir string) error {
 		return fmt.Errorf("docker image %q not found locally: %w", imageName, err)
 	}
 
-	// Use a temp lib directory for extraction so verify leaves no lasting state.
-	tmpLib, err := os.MkdirTemp("", "coral-verify-*")
+	labels, err := libs.GetImageLabels(imageName)
 	if err != nil {
-		return fmt.Errorf("creating temp lib dir: %w", err)
+		return fmt.Errorf("reading image labels: %w", err)
 	}
-	defer os.RemoveAll(tmpLib)
+	profile, ok := labels["coral.profile"]
+	if !ok || profile == "" {
+		return fmt.Errorf("missing required label 'coral.profile'; must be one of: drivers, skillsets, executors")
+	}
+	if !validProfiles[profile] {
+		return fmt.Errorf("invalid coral.profile=%q; must be one of: drivers, skillsets, executors", profile)
+	}
+	fmt.Println(logging.Info(fmt.Sprintf("coral.profile=%q", profile)))
+
+	libPath, err := readImageEnv(imageName, "CORAL_EXPORT_LIB")
+	if err != nil {
+		return fmt.Errorf("reading CORAL_EXPORT_LIB from image: %w", err)
+	}
+
+	if libPath == "" {
+		if profile == "skillsets" {
+			return fmt.Errorf("skillsets profile requires CORAL_EXPORT_LIB to be set in the image")
+		}
+		fmt.Println(logging.Info("CORAL_EXPORT_LIB not set"))
+		return nil
+	}
+
+	tmpDir, err := os.MkdirTemp("", "coral-verify-*")
+	if err != nil {
+		return fmt.Errorf("creating temp dir: %w", err)
+	}
+	defer os.RemoveAll(tmpDir)
 	if libDir != "" {
-		tmpLib = libDir
+		tmpDir = libDir
 	}
 
-	_, _, err = libs.ExtractLibraries(imageName, "verify", tmpLib)
+	uid := uuid.New()
+	probeName := fmt.Sprintf("coral-probe-%x", uid[:4])
+	createCmd := exec.Command("docker", "create", "--name", probeName, imageName)
+	createCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	createOut, err := createCmd.Output()
 	if err != nil {
-		return fmt.Errorf("extraction failed — ensure CORAL_EXPORT_LIB is set and contains behaviors/ and interfaces/: %w", err)
+		return fmt.Errorf("creating probe container: %w", err)
+	}
+	containerID := strings.TrimSpace(string(createOut))
+	defer func() {
+		rmCmd := exec.Command("docker", "rm", containerID)
+		rmCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+		rmCmd.Run()
+	}()
+
+	cpCmd := exec.Command("docker", "cp",
+		fmt.Sprintf("%s:%s", containerID, libPath),
+		tmpDir)
+	cpCmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if cpOut, err := cpCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("copying CORAL_EXPORT_LIB from container: %w\n%s", err, cpOut)
 	}
 
-	fmt.Println(logging.Info("CORAL_EXPORT_LIB is set and library extraction succeeded"))
+	exportedDir := filepath.Join(tmpDir, filepath.Base(libPath))
+
+	info, err := os.Stat(exportedDir)
+	if err != nil {
+		return fmt.Errorf("stating exported lib dir: %w", err)
+	}
+	mode := info.Mode().Perm()
+	if mode&0005 != 0005 {
+		return fmt.Errorf(
+			"CORAL_EXPORT_LIB=%s lacks world read+execute permissions (mode %04o); add 'RUN chmod o+rx %s' to the Dockerfile",
+			libPath, mode, libPath,
+		)
+	}
+	fmt.Println(logging.Info(fmt.Sprintf("CORAL_EXPORT_LIB=%s permissions OK (%04o)", libPath, mode)))
+
+	entries, err := os.ReadDir(exportedDir)
+	if err != nil {
+		return fmt.Errorf("reading exported lib dir: %w", err)
+	}
+	if len(entries) == 0 {
+		return fmt.Errorf(
+			"CORAL_EXPORT_LIB=%s is empty; ensure the Dockerfile populates it before the image is built",
+			libPath,
+		)
+	}
+	fmt.Println(logging.Info(fmt.Sprintf("CORAL_EXPORT_LIB=%s is populated (%d entries)", libPath, len(entries))))
+
+	if profile == "skillsets" {
+		var behaviorLibs []string
+		if err := filepath.WalkDir(exportedDir, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			name := d.Name()
+			if !d.IsDir() && strings.HasPrefix(name, "lib") && strings.HasSuffix(name, "behaviors.so") {
+				behaviorLibs = append(behaviorLibs, name)
+			}
+			return nil
+		}); err != nil {
+			return fmt.Errorf("scanning CORAL_EXPORT_LIB for behavior libraries: %w", err)
+		}
+		if len(behaviorLibs) == 0 {
+			return fmt.Errorf(
+				"skillsets profile requires at least one lib*behaviors.so in CORAL_EXPORT_LIB=%s; found none",
+				libPath,
+			)
+		}
+		fmt.Println(logging.Info(fmt.Sprintf("Found behavior lib(s): %s", strings.Join(behaviorLibs, ", "))))
+	}
+
 	return nil
+}
+
+// reads an environment variable baked into an image without creating a container
+func readImageEnv(image, varName string) (string, error) {
+	out, err := exec.Command("docker", "inspect", "--format", "{{json .Config.Env}}", image).Output()
+	if err != nil {
+		return "", fmt.Errorf("inspecting image env: %w", err)
+	}
+	var envs []string
+	if err := json.Unmarshal([]byte(strings.TrimSpace(string(out))), &envs); err != nil {
+		return "", fmt.Errorf("parsing image env JSON: %w", err)
+	}
+	prefix := varName + "="
+	for _, e := range envs {
+		if strings.HasPrefix(e, prefix) {
+			return e[len(prefix):], nil
+		}
+	}
+	return "", nil
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -19,7 +19,7 @@ var versionCmd = &cobra.Command{
 	},
 }
 
-// parseMajorVersion extracts the leading integer from a version string of the form [v]MAJOR[.MINOR[.PATCH[...]]].
+// extracts the leading integer from a version string of the form [v]MAJOR[.MINOR[.PATCH[...]]].
 func parseMajorVersion(v string) (int, error) {
 	v = strings.TrimPrefix(v, "v")
 	if i := strings.IndexByte(v, '.'); i != -1 {

--- a/internal/inspect/format.go
+++ b/internal/inspect/format.go
@@ -8,22 +8,16 @@ import (
 	"strings"
 )
 
-// ImageMetadata holds image-level information recovered from docker inspect.
-// OCI holds org.opencontainers.image.* values with the prefix stripped.
-// Labels holds coral.* labels verbatim.
 type ImageMetadata struct {
 	OCI    map[string]string `json:"oci,omitempty"`
 	Labels map[string]string `json:"labels,omitempty"`
 }
 
-// ociPromoted are rendered as structured prose rather than a generic table.
 var ociPromoted = map[string]bool{
 	"title": true, "description": true, "version": true, "authors": true,
 	"url": true, "source": true, "documentation": true, "licenses": true,
 }
 
-// ParseBehaviors parses the flat JSON object from coral-inspect into a map of
-// behavior name -> raw JSON, preserving fields the formatter doesn't recognize.
 func ParseBehaviors(raw []byte) (map[string]json.RawMessage, error) {
 	var m map[string]json.RawMessage
 	if err := json.Unmarshal(raw, &m); err != nil {
@@ -32,8 +26,6 @@ func ParseBehaviors(raw []byte) (map[string]json.RawMessage, error) {
 	return m, nil
 }
 
-// FormatJSON wraps everything into a single object and pretty-prints.
-// All behavior fields from the original JSON are preserved.
 func FormatJSON(image string, meta ImageMetadata, behaviors map[string]json.RawMessage) ([]byte, error) {
 	wrapper := struct {
 		Image     string                     `json:"image"`
@@ -44,11 +36,10 @@ func FormatJSON(image string, meta ImageMetadata, behaviors map[string]json.RawM
 	return json.MarshalIndent(wrapper, "", "  ")
 }
 
-// FormatMarkdown renders the full image digest as Markdown.
 func FormatMarkdown(image string, meta ImageMetadata, behaviors map[string]json.RawMessage) string {
 	var sb strings.Builder
 
-	// Heading: prefer OCI title, fall back to image name.
+	// heading: prefer OCI title, fall back to image name
 	title := meta.OCI["title"]
 	if title != "" {
 		fmt.Fprintf(&sb, "# %s\n", title)
@@ -57,12 +48,12 @@ func FormatMarkdown(image string, meta ImageMetadata, behaviors map[string]json.
 		fmt.Fprintf(&sb, "# %s\n\n", image)
 	}
 
-	// Description as a paragraph.
+	// description
 	if desc := meta.OCI["description"]; desc != "" {
 		fmt.Fprintf(&sb, "%s\n\n", desc)
 	}
 
-	// Version / authors / licenses on one line.
+	// version / authors / licenses on one line
 	var inlineFields []string
 	for _, key := range []string{"version", "authors", "licenses"} {
 		if v := meta.OCI[key]; v != "" {
@@ -74,7 +65,7 @@ func FormatMarkdown(image string, meta ImageMetadata, behaviors map[string]json.
 		sb.WriteString("\n\n")
 	}
 
-	// URL / source / documentation as links.
+	// URL / source / documentation as links
 	for _, key := range []string{"url", "source", "documentation"} {
 		if v := meta.OCI[key]; v != "" {
 			fmt.Fprintf(&sb, "**%s**: <%s>  \n", key, v)
@@ -85,7 +76,7 @@ func FormatMarkdown(image string, meta ImageMetadata, behaviors map[string]json.
 		sb.WriteString("\n")
 	}
 
-	// Any remaining OCI fields not handled above.
+	// any remaining OCI fields not handled above
 	var ociExtras []string
 	for k := range meta.OCI {
 		if !ociPromoted[k] {
@@ -102,7 +93,7 @@ func FormatMarkdown(image string, meta ImageMetadata, behaviors map[string]json.
 		sb.WriteString("\n")
 	}
 
-	// Coral labels table.
+	// coral labels
 	if len(meta.Labels) > 0 {
 		sb.WriteString("| Label | Value |\n")
 		sb.WriteString("|-------|-------|\n")
@@ -119,7 +110,7 @@ func FormatMarkdown(image string, meta ImageMetadata, behaviors map[string]json.
 
 	sb.WriteString("---\n\n")
 
-	// Behaviors.
+	// behaviors
 	knownBehaviorFields := map[string]bool{"description": true, "inputs": true, "outputs": true}
 
 	for _, name := range sortedRawKeys(behaviors) {

--- a/internal/inspect/format.go
+++ b/internal/inspect/format.go
@@ -8,6 +8,20 @@ import (
 	"strings"
 )
 
+// ImageMetadata holds image-level information recovered from docker inspect.
+// OCI holds org.opencontainers.image.* values with the prefix stripped.
+// Labels holds coral.* labels verbatim.
+type ImageMetadata struct {
+	OCI    map[string]string `json:"oci,omitempty"`
+	Labels map[string]string `json:"labels,omitempty"`
+}
+
+// ociPromoted are rendered as structured prose rather than a generic table.
+var ociPromoted = map[string]bool{
+	"title": true, "description": true, "version": true, "authors": true,
+	"url": true, "source": true, "documentation": true, "licenses": true,
+}
+
 // ParseBehaviors parses the flat JSON object from coral-inspect into a map of
 // behavior name -> raw JSON, preserving fields the formatter doesn't recognize.
 func ParseBehaviors(raw []byte) (map[string]json.RawMessage, error) {
@@ -18,28 +32,94 @@ func ParseBehaviors(raw []byte) (map[string]json.RawMessage, error) {
 	return m, nil
 }
 
-// FormatJSON wraps behaviors with the source image name and pretty-prints.
-// All fields from the original JSON are preserved.
-func FormatJSON(image string, behaviors map[string]json.RawMessage) ([]byte, error) {
+// FormatJSON wraps everything into a single object and pretty-prints.
+// All behavior fields from the original JSON are preserved.
+func FormatJSON(image string, meta ImageMetadata, behaviors map[string]json.RawMessage) ([]byte, error) {
 	wrapper := struct {
 		Image     string                     `json:"image"`
+		OCI       map[string]string          `json:"oci,omitempty"`
+		Labels    map[string]string          `json:"labels,omitempty"`
 		Behaviors map[string]json.RawMessage `json:"behaviors"`
-	}{image, behaviors}
+	}{image, meta.OCI, meta.Labels, behaviors}
 	return json.MarshalIndent(wrapper, "", "  ")
 }
 
-// FormatMarkdown renders behaviors as Markdown. Known fields (description, inputs,
-// outputs) receive dedicated formatting; any unrecognized fields are appended as
-// key: value pairs so the output remains correct after schema extensions.
-func FormatMarkdown(image string, behaviors map[string]json.RawMessage) string {
+// FormatMarkdown renders the full image digest as Markdown.
+func FormatMarkdown(image string, meta ImageMetadata, behaviors map[string]json.RawMessage) string {
 	var sb strings.Builder
-	fmt.Fprintf(&sb, "# %s\n\n", image)
+
+	// Heading: prefer OCI title, fall back to image name.
+	title := meta.OCI["title"]
+	if title != "" {
+		fmt.Fprintf(&sb, "# %s\n", title)
+		fmt.Fprintf(&sb, "`%s`\n\n", image)
+	} else {
+		fmt.Fprintf(&sb, "# %s\n\n", image)
+	}
+
+	// Description as a paragraph.
+	if desc := meta.OCI["description"]; desc != "" {
+		fmt.Fprintf(&sb, "%s\n\n", desc)
+	}
+
+	// Version / authors / licenses on one line.
+	var inlineFields []string
+	for _, key := range []string{"version", "authors", "licenses"} {
+		if v := meta.OCI[key]; v != "" {
+			inlineFields = append(inlineFields, fmt.Sprintf("**%s**: %s", key, v))
+		}
+	}
+	if len(inlineFields) > 0 {
+		sb.WriteString(strings.Join(inlineFields, " · "))
+		sb.WriteString("\n\n")
+	}
+
+	// URL / source / documentation as links.
+	for _, key := range []string{"url", "source", "documentation"} {
+		if v := meta.OCI[key]; v != "" {
+			fmt.Fprintf(&sb, "**%s**: <%s>  \n", key, v)
+		}
+	}
+	if v := meta.OCI["url"]; v != "" || meta.OCI["source"] != "" || meta.OCI["documentation"] != "" {
+		_ = v
+		sb.WriteString("\n")
+	}
+
+	// Any remaining OCI fields not handled above.
+	var ociExtras []string
+	for k := range meta.OCI {
+		if !ociPromoted[k] {
+			ociExtras = append(ociExtras, k)
+		}
+	}
+	sort.Strings(ociExtras)
+	if len(ociExtras) > 0 {
+		sb.WriteString("| OCI Field | Value |\n")
+		sb.WriteString("|-----------|-------|\n")
+		for _, k := range ociExtras {
+			fmt.Fprintf(&sb, "| `%s` | `%s` |\n", k, meta.OCI[k])
+		}
+		sb.WriteString("\n")
+	}
+
+	// Coral labels table.
+	if len(meta.Labels) > 0 {
+		sb.WriteString("| Label | Value |\n")
+		sb.WriteString("|-------|-------|\n")
+		for _, k := range sortedStringKeys(meta.Labels) {
+			fmt.Fprintf(&sb, "| `%s` | `%s` |\n", k, meta.Labels[k])
+		}
+		sb.WriteString("\n")
+	}
 
 	if len(behaviors) == 0 {
 		sb.WriteString("No behaviors exported.\n")
 		return sb.String()
 	}
 
+	sb.WriteString("---\n\n")
+
+	// Behaviors.
 	knownBehaviorFields := map[string]bool{"description": true, "inputs": true, "outputs": true}
 
 	for _, name := range sortedRawKeys(behaviors) {
@@ -137,6 +217,15 @@ func stringField(fields map[string]json.RawMessage, key string) string {
 }
 
 func sortedRawKeys(m map[string]json.RawMessage) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func sortedStringKeys(m map[string]string) []string {
 	keys := make([]string, 0, len(m))
 	for k := range m {
 		keys = append(keys, k)

--- a/internal/inspect/format.go
+++ b/internal/inspect/format.go
@@ -1,0 +1,161 @@
+package inspect
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// ParseBehaviors parses the flat JSON object from coral-inspect into a map of
+// behavior name -> raw JSON, preserving fields the formatter doesn't recognize.
+func ParseBehaviors(raw []byte) (map[string]json.RawMessage, error) {
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return nil, fmt.Errorf("parsing behavior JSON: %w", err)
+	}
+	return m, nil
+}
+
+// FormatJSON wraps behaviors with the source image name and pretty-prints.
+// All fields from the original JSON are preserved.
+func FormatJSON(image string, behaviors map[string]json.RawMessage) ([]byte, error) {
+	wrapper := struct {
+		Image     string                     `json:"image"`
+		Behaviors map[string]json.RawMessage `json:"behaviors"`
+	}{image, behaviors}
+	return json.MarshalIndent(wrapper, "", "  ")
+}
+
+// FormatMarkdown renders behaviors as Markdown. Known fields (description, inputs,
+// outputs) receive dedicated formatting; any unrecognized fields are appended as
+// key: value pairs so the output remains correct after schema extensions.
+func FormatMarkdown(image string, behaviors map[string]json.RawMessage) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "# %s\n\n", image)
+
+	if len(behaviors) == 0 {
+		sb.WriteString("No behaviors exported.\n")
+		return sb.String()
+	}
+
+	knownBehaviorFields := map[string]bool{"description": true, "inputs": true, "outputs": true}
+
+	for _, name := range sortedRawKeys(behaviors) {
+		fields := rawFields(behaviors[name])
+
+		fmt.Fprintf(&sb, "## `%s`\n", name)
+		if desc := stringField(fields, "description"); desc != "" && desc != name {
+			fmt.Fprintf(&sb, "%s\n", desc)
+		}
+		sb.WriteString("\n")
+
+		if inputs := portsField(fields, "inputs"); len(inputs) > 0 {
+			sb.WriteString("**Inputs**\n\n")
+			writePortTable(&sb, inputs)
+		}
+		if outputs := portsField(fields, "outputs"); len(outputs) > 0 {
+			sb.WriteString("**Outputs**\n\n")
+			writePortTable(&sb, outputs)
+		}
+
+		var extras []string
+		for k := range fields {
+			if !knownBehaviorFields[k] {
+				extras = append(extras, k)
+			}
+		}
+		sort.Strings(extras)
+		for _, k := range extras {
+			fmt.Fprintf(&sb, "**%s**: %s\n\n", k, compactJSON(fields[k]))
+		}
+
+		sb.WriteString("---\n\n")
+	}
+
+	return sb.String()
+}
+
+func writePortTable(sb *strings.Builder, ports map[string]json.RawMessage) {
+	hasDefault := false
+	for _, raw := range ports {
+		if _, ok := rawFields(raw)["default"]; ok {
+			hasDefault = true
+			break
+		}
+	}
+
+	if hasDefault {
+		sb.WriteString("| Port | Type | Default | Description |\n")
+		sb.WriteString("|------|------|---------|-------------|\n")
+	} else {
+		sb.WriteString("| Port | Type | Description |\n")
+		sb.WriteString("|------|------|-------------|\n")
+	}
+
+	for _, portName := range sortedRawKeys(ports) {
+		pf := rawFields(ports[portName])
+		typ := stringField(pf, "type")
+		desc := stringField(pf, "description")
+		if hasDefault {
+			fmt.Fprintf(sb, "| `%s` | `%s` | %s | %s |\n",
+				portName, typ, backtickOrEmpty(stringField(pf, "default")), desc)
+		} else {
+			fmt.Fprintf(sb, "| `%s` | `%s` | %s |\n", portName, typ, desc)
+		}
+	}
+	sb.WriteString("\n")
+}
+
+func rawFields(raw json.RawMessage) map[string]json.RawMessage {
+	var m map[string]json.RawMessage
+	json.Unmarshal(raw, &m) //nolint:errcheck
+	return m
+}
+
+func portsField(fields map[string]json.RawMessage, key string) map[string]json.RawMessage {
+	raw, ok := fields[key]
+	if !ok {
+		return nil
+	}
+	var ports map[string]json.RawMessage
+	json.Unmarshal(raw, &ports) //nolint:errcheck
+	return ports
+}
+
+func stringField(fields map[string]json.RawMessage, key string) string {
+	raw, ok := fields[key]
+	if !ok {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return string(raw)
+	}
+	return s
+}
+
+func sortedRawKeys(m map[string]json.RawMessage) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func compactJSON(raw json.RawMessage) string {
+	var buf bytes.Buffer
+	if err := json.Compact(&buf, raw); err != nil {
+		return string(raw)
+	}
+	return buf.String()
+}
+
+func backtickOrEmpty(s string) string {
+	if s == "" {
+		return ""
+	}
+	return "`" + s + "`"
+}


### PR DESCRIPTION
Added several commands:
- **`inspect`** amalgamates metadata from a Coral component and generates a manifest of its afforded behaviors.
- **`generate`** creates a full template skeleton for a new Coral component.
- **`version`** presents the CLI version.

And changes to other commands:
- **`verify`** now checks labels, environment variables, and permissions in a manner consistent with CLI v2.x.x.