### PR TITLE
added extract command for OCI archives

### DIFF
--- a/cmd/extract.go
+++ b/cmd/extract.go
@@ -1,0 +1,359 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"coral_cli/internal/logging"
+	"coral_cli/internal/ociarchive"
+)
+
+var (
+	extractOutput    string
+	extractPath      string
+	extractEnvVar    string
+	extractPlatforms []string
+	extractLayout    string
+	extractList      bool
+)
+
+const (
+	defaultExtractEnv    = "CORAL_EXPORT_LIB"
+	defaultExtractLayout = "{os}/{arch}/{variant}"
+)
+
+func init() {
+	extractCmd.Flags().StringVarP(&extractOutput, "output", "o", "", "Output directory (default: the archive filename without its extension)")
+	extractCmd.Flags().StringVar(&extractPath, "path", "", "Image path to extract (default: the value of CORAL_EXPORT_LIB in each image)")
+	extractCmd.Flags().StringVar(&extractEnvVar, "env", defaultExtractEnv, "Environment variable naming the path to extract")
+	extractCmd.Flags().StringSliceVar(&extractPlatforms, "platform", nil, "Only extract these platforms, e.g. linux/amd64,linux/arm64 (default: all)")
+	extractCmd.Flags().StringVar(&extractLayout, "layout", defaultExtractLayout, "Template for each image's output subdirectory")
+	extractCmd.Flags().BoolVar(&extractList, "list", false, "List the platforms in the archive without extracting anything")
+
+	extractCmd.ValidArgsFunction = func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) > 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		return []string{"tar"}, cobra.ShellCompDirectiveFilterFileExt
+	}
+}
+
+var extractCmd = &cobra.Command{
+	Use:   "extract <file>",
+	Short: "Extract a library tree from every architecture in an OCI archive",
+	Long: `Extract files from every image variant held in an OCI archive (.tar).
+
+Unlike coral load, which installs only the variant matching the current platform,
+extract reads all of them — including variants built for a foreign CPU
+architecture. It reads the archive directly, so it needs neither a container
+runtime nor skopeo, and the local daemon's refusal to hold a foreign-arch image
+does not apply (nothing is ever executed, only read).
+
+For each image, the path named by CORAL_EXPORT_LIB in that image's environment
+is written to its own subdirectory of the output directory. The image's layers
+are flattened in order with whiteouts applied, so the result matches what the
+running container would see at that path. Modification times are preserved.
+
+An extract.json file records, per variant, its platform, digests, config
+labels, and the path that was extracted.
+
+The output subdirectory is named by --layout, which accepts the tokens {os},
+{arch}, {variant}, {distro} (the coral.ros_distro label), {version}, and {title}
+(the org.opencontainers.image.* labels). Tokens that resolve to nothing are
+dropped, so the default leaves an image with no CPU variant at linux/arm64
+rather than linux/arm64/.`,
+	Example: `  # every architecture, laid out as <os>/<arch>
+  coral extract realsense-humble.tar -o ./staging
+
+  # group by ROS distro instead, one architecture only
+  coral extract realsense-humble.tar --layout '{distro}/{arch}' --platform linux/arm64
+
+  # see what is in the archive
+  coral extract realsense-humble.tar --list`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return extract(args[0])
+	},
+}
+
+// one image variant's entry in the extract.json sidecar
+type extractedImage struct {
+	Dir            string              `json:"dir"`
+	Platform       ociarchive.Platform `json:"platform"`
+	ManifestDigest string              `json:"manifest_digest"`
+	ConfigDigest   string              `json:"config_digest"`
+	SourcePath     string              `json:"source_path"`
+	Labels         map[string]string   `json:"labels,omitempty"`
+	Files          int                 `json:"files"`
+	Symlinks       int                 `json:"symlinks"`
+	Bytes          int64               `json:"bytes"`
+}
+
+type extractManifest struct {
+	Archive     string           `json:"archive"`
+	ExtractedAt string           `json:"extracted_at"`
+	SourceEnv   string           `json:"source_env,omitempty"`
+	Images      []extractedImage `json:"images"`
+}
+
+func extract(archivePath string) error {
+	archive, err := ociarchive.Open(archivePath)
+	if err != nil {
+		return err
+	}
+
+	images, err := archive.Images()
+	if err != nil {
+		return err
+	}
+
+	selected, err := selectPlatforms(images, extractPlatforms)
+	if err != nil {
+		return err
+	}
+
+	if extractList {
+		for _, img := range selected {
+			source := img.Env[extractEnvVar]
+			if source == "" {
+				source = logging.Yellow(fmt.Sprintf("no %s", extractEnvVar))
+			}
+			fmt.Printf("  %-20s %s\n", logging.BoldMagenta(img.Platform.String()), source)
+		}
+		return nil
+	}
+
+	output := extractOutput
+	if output == "" {
+		base := filepath.Base(archivePath)
+		output = strings.TrimSuffix(base, filepath.Ext(base))
+	}
+
+	dirs, err := resolveDirs(selected, extractLayout)
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(logging.Info(fmt.Sprintf("Extracting %d platform(s) from %s → %s",
+		len(selected), archivePath, output)))
+
+	result := extractManifest{
+		Archive:     filepath.Base(archivePath),
+		ExtractedAt: time.Now().UTC().Format(time.RFC3339),
+	}
+	if extractPath == "" {
+		result.SourceEnv = extractEnvVar
+	}
+
+	var skipped []string
+	for i, img := range selected {
+		source := extractPath
+		if source == "" {
+			source = img.Env[extractEnvVar]
+		}
+		if source == "" {
+			skipped = append(skipped, fmt.Sprintf("%s does not set %s", img.Platform, extractEnvVar))
+			continue
+		}
+
+		dest := filepath.Join(output, filepath.FromSlash(dirs[i]))
+		// clear only this variant's directory, so several archives may share an output root without one stale run polluting the next
+		if err := os.RemoveAll(dest); err != nil {
+			return fmt.Errorf("clearing %s: %w", dest, err)
+		}
+
+		res, err := archive.ExtractSubtree(img, source, dest)
+		if err != nil {
+			return fmt.Errorf("extracting %s: %w", img.Platform, err)
+		}
+		for _, w := range res.Warnings {
+			fmt.Println(logging.Warning(fmt.Sprintf("%s: %s", img.Platform, w)))
+		}
+		if res.Files == 0 && res.Symlinks == 0 {
+			fmt.Println(logging.Warning(fmt.Sprintf(
+				"%s: %s is empty in this image", img.Platform, source)))
+		}
+
+		fmt.Printf("  %-20s %s  (%d files, %d symlinks, %s)\n",
+			logging.BoldMagenta(img.Platform.String()), dirs[i],
+			res.Files, res.Symlinks, humanBytes(res.Bytes))
+
+		result.Images = append(result.Images, extractedImage{
+			Dir:            dirs[i],
+			Platform:       img.Platform,
+			ManifestDigest: img.ManifestDigest,
+			ConfigDigest:   img.ConfigDigest,
+			SourcePath:     source,
+			Labels:         img.Labels,
+			Files:          res.Files,
+			Symlinks:       res.Symlinks,
+			Bytes:          res.Bytes,
+		})
+	}
+
+	for _, s := range skipped {
+		fmt.Println(logging.Warning("Skipped: " + s))
+	}
+	if len(result.Images) == 0 {
+		return fmt.Errorf("nothing extracted: no image in %s sets %s; pass --path to extract a fixed path instead",
+			archivePath, extractEnvVar)
+	}
+
+	sidecar := filepath.Join(output, "extract.json")
+	data, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return fmt.Errorf("serializing extract.json: %w", err)
+	}
+	if err := os.WriteFile(sidecar, append(data, '\n'), 0o644); err != nil {
+		return fmt.Errorf("writing %s: %w", sidecar, err)
+	}
+
+	fmt.Println(logging.Success(fmt.Sprintf("Extracted %d platform(s) to %s", len(result.Images), output)))
+	return nil
+}
+
+// selectPlatforms filters images by the --platform values, which may be given as "linux/amd64", "amd64", or "linux/arm64/v8"
+func selectPlatforms(images []ociarchive.Image, wanted []string) ([]ociarchive.Image, error) {
+	if len(wanted) == 0 {
+		return images, nil
+	}
+
+	var selected []ociarchive.Image
+	matched := make(map[string]bool, len(wanted))
+	for _, img := range images {
+		for _, w := range wanted {
+			if platformMatches(img.Platform, w) {
+				selected = append(selected, img)
+				matched[w] = true
+				break
+			}
+		}
+	}
+
+	var missing []string
+	for _, w := range wanted {
+		if !matched[w] {
+			missing = append(missing, w)
+		}
+	}
+	if len(missing) > 0 {
+		var available []string
+		for _, img := range images {
+			available = append(available, img.Platform.String())
+		}
+		return nil, fmt.Errorf("no image for platform %s; the archive holds: %s",
+			strings.Join(missing, ", "), strings.Join(available, ", "))
+	}
+	return selected, nil
+}
+
+func platformMatches(p ociarchive.Platform, want string) bool {
+	switch parts := strings.Split(want, "/"); len(parts) {
+	case 1:
+		return p.Architecture == parts[0]
+	case 2:
+		return p.OS == parts[0] && p.Architecture == parts[1]
+	case 3:
+		return p.OS == parts[0] && p.Architecture == parts[1] && p.Variant == parts[2]
+	default:
+		return false
+	}
+}
+
+// resolveDirs renders the layout template for each image and rejects a template that cannot tell two variants apart
+func resolveDirs(images []ociarchive.Image, layout string) ([]string, error) {
+	dirs := make([]string, len(images))
+	claimed := map[string]ociarchive.Platform{}
+
+	for i, img := range images {
+		dir, err := renderLayout(layout, img)
+		if err != nil {
+			return nil, err
+		}
+		if prior, taken := claimed[dir]; taken {
+			return nil, fmt.Errorf("layout %q puts both %s and %s in %q; choose a layout that distinguishes them",
+				layout, prior, img.Platform, dir)
+		}
+		claimed[dir] = img.Platform
+		dirs[i] = dir
+	}
+	return dirs, nil
+}
+
+// renderLayout substitutes the layout tokens for one image. Segments that resolve to nothing are dropped rather than left empty
+func renderLayout(layout string, img ociarchive.Image) (string, error) {
+	values := map[string]string{
+		"os":      img.Platform.OS,
+		"arch":    img.Platform.Architecture,
+		"variant": img.Platform.Variant,
+		"distro":  img.Labels["coral.ros_distro"],
+		"version": img.Labels["org.opencontainers.image.version"],
+		"title":   img.Labels["org.opencontainers.image.title"],
+	}
+
+	var rendered []string
+	for _, segment := range strings.Split(layout, "/") {
+		out := segment
+		for {
+			open := strings.Index(out, "{")
+			if open < 0 {
+				break
+			}
+			close := strings.Index(out[open:], "}")
+			if close < 0 {
+				return "", fmt.Errorf("layout %q has an unclosed '{'", layout)
+			}
+			close += open
+			token := out[open+1 : close]
+			value, known := values[token]
+			if !known {
+				return "", fmt.Errorf("layout %q uses unknown token {%s}; valid tokens are {os}, {arch}, {variant}, {distro}, {version}, {title}", layout, token)
+			}
+			out = out[:open] + value + out[close+1:]
+		}
+		out = sanitizeSegment(out)
+		if out != "" {
+			rendered = append(rendered, out)
+		}
+	}
+
+	if len(rendered) == 0 {
+		return "", fmt.Errorf("layout %q resolved to an empty path for %s; every token was empty", layout, img.Platform)
+	}
+	return strings.Join(rendered, "/"), nil
+}
+
+// sanitizeSegment keeps a rendered token from introducing path structure of its own; label values are author-supplied and may hold slashes or colons
+func sanitizeSegment(s string) string {
+	s = strings.Map(func(r rune) rune {
+		switch r {
+		case '/', '\\', ':', 0:
+			return '-'
+		}
+		return r
+	}, s)
+	s = strings.TrimSpace(s)
+	if s == "." || s == ".." {
+		return ""
+	}
+	return s
+}
+
+func humanBytes(n int64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	div, exp := int64(unit), 0
+	for v := n / unit; v >= unit; v /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(n)/float64(div), "KMGTPE"[exp])
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -82,7 +82,7 @@ func runDockerCommand(args ...string) error {
 	return nil
 }
 
-// decodes the output of `runtime __complete` into the completions and directive that Cobra expects from a ValidArgsFunction.
+// decodes the output of `runtime __complete` into the completions and directive that Cobra expects from a ValidArgsFunction
 func parseRuntimeCompletion(out []byte) ([]string, cobra.ShellCompDirective) {
 	directive := cobra.ShellCompDirectiveNoFileComp
 	var completions []string
@@ -221,6 +221,7 @@ func init() {
 
 	// commands that do not overload docker commands belong here
 	rootCmd.AddCommand(completionCmd)
+	rootCmd.AddCommand(extractCmd)
 	rootCmd.AddCommand(generateCmd)
 	rootCmd.AddCommand(healthCmd)
 	rootCmd.AddCommand(inspectCmd)

--- a/internal/ociarchive/archive.go
+++ b/internal/ociarchive/archive.go
@@ -1,0 +1,314 @@
+package ociarchive
+
+import (
+	"archive/tar"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"strings"
+)
+
+// media types that identify a manifest list (an index over per-platform manifests)
+var indexMediaTypes = map[string]bool{
+	"application/vnd.oci.image.index.v1+json":                   true,
+	"application/vnd.docker.distribution.manifest.list.v2+json": true,
+}
+
+// media types that identify a single-platform image manifest
+var manifestMediaTypes = map[string]bool{
+	"application/vnd.oci.image.manifest.v1+json":           true,
+	"application/vnd.docker.distribution.manifest.v2+json": true,
+}
+
+// blobs that describe a layer held elsewhere; they are not present in the archive
+var foreignLayerMediaTypes = map[string]bool{
+	"application/vnd.oci.image.layer.nondistributable.v1.tar":      true,
+	"application/vnd.oci.image.layer.nondistributable.v1.tar+gzip": true,
+	"application/vnd.docker.image.rootfs.foreign.diff.tar.gzip":    true,
+}
+
+// largest JSON blob (index, manifest, or config) that will be read into memory; these are kilobytes in practice, so the cap only guards against a malformed archive
+const maxJSONBlob = 32 << 20
+
+// Platform identifies the OS/CPU a particular image variant was built for
+type Platform struct {
+	OS           string `json:"os"`
+	Architecture string `json:"architecture"`
+	Variant      string `json:"variant,omitempty"`
+}
+
+// String renders the platform in the conventional "linux/arm64/v8" form
+func (p Platform) String() string {
+	s := p.OS + "/" + p.Architecture
+	if p.Variant != "" {
+		s += "/" + p.Variant
+	}
+	return s
+}
+
+// Descriptor is the subset of an OCI content descriptor this package needs
+type Descriptor struct {
+	MediaType   string            `json:"mediaType"`
+	Digest      string            `json:"digest"`
+	Size        int64             `json:"size"`
+	Platform    *Platform         `json:"platform,omitempty"`
+	Annotations map[string]string `json:"annotations,omitempty"`
+}
+
+// isAttestation reports whether a descriptor names a buildx attestation manifest
+func (d Descriptor) isAttestation() bool {
+	if d.Annotations["vnd.docker.reference.type"] == "attestation-manifest" {
+		return true
+	}
+	return d.Platform != nil && isPlaceholderPlatform(*d.Platform)
+}
+
+// isPlaceholderPlatform reports whether a platform carries no usable identity: either buildx's literal "unknown/unknown" or nothing at all
+func isPlaceholderPlatform(p Platform) bool {
+	if p.OS == "unknown" || p.Architecture == "unknown" {
+		return true
+	}
+	return p.OS == "" && p.Architecture == ""
+}
+
+type ociIndex struct {
+	Manifests []Descriptor `json:"manifests"`
+}
+
+type ociManifest struct {
+	Config Descriptor   `json:"config"`
+	Layers []Descriptor `json:"layers"`
+}
+
+type ociConfig struct {
+	Architecture string `json:"architecture"`
+	OS           string `json:"os"`
+	Variant      string `json:"variant,omitempty"`
+	Config       struct {
+		Env    []string          `json:"Env"`
+		Labels map[string]string `json:"Labels"`
+	} `json:"config"`
+}
+
+// Image is one platform variant held in the archive, resolved far enough to extract from: its platform, its config metadata, and its ordered layer list
+type Image struct {
+	Platform       Platform
+	ManifestDigest string
+	ConfigDigest   string
+	// labels from the image config, e.g. coral.ros_distro, coral.btcpp_version
+	Labels map[string]string
+	// env from the image config, split into key/value
+	Env    map[string]string
+	layers []Descriptor
+}
+
+// archive is a read-only handle on an oci-archive .tar file
+type Archive struct {
+	path string
+}
+
+// Open validates that path is an OCI archive and returns a handle on it
+func Open(path string) (*Archive, error) {
+	if _, err := os.Stat(path); err != nil {
+		return nil, fmt.Errorf("opening archive: %w", err)
+	}
+	a := &Archive{path: path}
+	if _, err := a.readMember("index.json"); err != nil {
+		if _, dockerErr := a.readMember("manifest.json"); dockerErr == nil {
+			return nil, fmt.Errorf("%s is a docker-archive, not an OCI archive: it holds only one platform; rebuild it with `coral save`", path)
+		}
+		return nil, fmt.Errorf("%s does not look like an OCI archive (no index.json): %w", path, err)
+	}
+	return a, nil
+}
+
+// Path returns the archive's filesystem path
+func (a *Archive) Path() string { return a.path }
+
+// Images returns every platform variant in the archive, in index order, descending through nested indexes
+func (a *Archive) Images() ([]Image, error) {
+	raw, err := a.readMember("index.json")
+	if err != nil {
+		return nil, err
+	}
+	var idx ociIndex
+	if err := json.Unmarshal(raw, &idx); err != nil {
+		return nil, fmt.Errorf("parsing index.json: %w", err)
+	}
+
+	var images []Image
+	seen := map[string]bool{}
+	if err := a.collect(idx.Manifests, seen, &images); err != nil {
+		return nil, err
+	}
+	if len(images) == 0 {
+		return nil, fmt.Errorf("archive %s holds no image manifests", a.path)
+	}
+	return images, nil
+}
+
+// collect walks a descriptor list, recursing into nested indexes and resolving each image manifest it reaches
+func (a *Archive) collect(descs []Descriptor, seen map[string]bool, out *[]Image) error {
+	for _, desc := range descs {
+		if seen[desc.Digest] {
+			continue
+		}
+		seen[desc.Digest] = true
+
+		switch {
+		case indexMediaTypes[desc.MediaType]:
+			raw, err := a.readBlob(desc.Digest)
+			if err != nil {
+				return fmt.Errorf("reading nested index %s: %w", desc.Digest, err)
+			}
+			var nested ociIndex
+			if err := json.Unmarshal(raw, &nested); err != nil {
+				return fmt.Errorf("parsing nested index %s: %w", desc.Digest, err)
+			}
+			if err := a.collect(nested.Manifests, seen, out); err != nil {
+				return err
+			}
+
+		case manifestMediaTypes[desc.MediaType]:
+			if desc.isAttestation() {
+				continue
+			}
+			img, err := a.resolveImage(desc)
+			if err != nil {
+				return err
+			}
+			// an attestation whose descriptor carried neither annotation nor platform is still identifiable once its config has been read
+			if isPlaceholderPlatform(img.Platform) {
+				continue
+			}
+			*out = append(*out, img)
+
+		default:
+			// signatures and other non-image entries live in the same index; skipping them by media type is the intended filter
+			continue
+		}
+	}
+	return nil
+}
+
+// resolveImage reads a manifest and its config into an Image
+func (a *Archive) resolveImage(desc Descriptor) (Image, error) {
+	raw, err := a.readBlob(desc.Digest)
+	if err != nil {
+		return Image{}, fmt.Errorf("reading manifest %s: %w", desc.Digest, err)
+	}
+	var mf ociManifest
+	if err := json.Unmarshal(raw, &mf); err != nil {
+		return Image{}, fmt.Errorf("parsing manifest %s: %w", desc.Digest, err)
+	}
+
+	rawCfg, err := a.readBlob(mf.Config.Digest)
+	if err != nil {
+		return Image{}, fmt.Errorf("reading config %s: %w", mf.Config.Digest, err)
+	}
+	var cfg ociConfig
+	if err := json.Unmarshal(rawCfg, &cfg); err != nil {
+		return Image{}, fmt.Errorf("parsing config %s: %w", mf.Config.Digest, err)
+	}
+
+	plat := Platform{OS: cfg.OS, Architecture: cfg.Architecture, Variant: cfg.Variant}
+	if desc.Platform != nil && desc.Platform.Architecture != "" {
+		plat = *desc.Platform
+	}
+
+	env := make(map[string]string, len(cfg.Config.Env))
+	for _, e := range cfg.Config.Env {
+		if k, v, ok := strings.Cut(e, "="); ok {
+			env[k] = v
+		}
+	}
+	labels := cfg.Config.Labels
+	if labels == nil {
+		labels = map[string]string{}
+	}
+
+	return Image{
+		Platform:       plat,
+		ManifestDigest: desc.Digest,
+		ConfigDigest:   mf.Config.Digest,
+		Labels:         labels,
+		Env:            env,
+		layers:         mf.Layers,
+	}, nil
+}
+
+// readBlob reads a content-addressed blob fully into memory
+func (a *Archive) readBlob(digest string) ([]byte, error) {
+	name, err := blobMember(digest)
+	if err != nil {
+		return nil, err
+	}
+	return a.readMember(name)
+}
+
+// openBlob streams a blob
+func (a *Archive) openBlob(digest string) (io.ReadCloser, error) {
+	name, err := blobMember(digest)
+	if err != nil {
+		return nil, err
+	}
+	return a.openMember(name)
+}
+
+func (a *Archive) readMember(name string) ([]byte, error) {
+	rc, err := a.openMember(name)
+	if err != nil {
+		return nil, err
+	}
+	defer rc.Close()
+	return io.ReadAll(io.LimitReader(rc, maxJSONBlob))
+}
+
+// openMember scans the archive for a named regular-file member and returns a reader positioned at its contents
+func (a *Archive) openMember(name string) (io.ReadCloser, error) {
+	f, err := os.Open(a.path)
+	if err != nil {
+		return nil, err
+	}
+	tr := tar.NewReader(f)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			f.Close()
+			return nil, fmt.Errorf("%q not found in archive", name)
+		}
+		if err != nil {
+			f.Close()
+			return nil, fmt.Errorf("reading archive: %w", err)
+		}
+		if hdr.Typeflag != tar.TypeReg || normalizeMember(hdr.Name) != name {
+			continue
+		}
+		return &memberReader{r: tr, f: f}, nil
+	}
+}
+
+// memberReader ties a tar member's contents to the file handle backing it
+type memberReader struct {
+	r io.Reader
+	f *os.File
+}
+
+func (m *memberReader) Read(p []byte) (int, error) { return m.r.Read(p) }
+func (m *memberReader) Close() error               { return m.f.Close() }
+
+// blobMember maps "sha256:abc..." to its path within the layout
+func blobMember(digest string) (string, error) {
+	alg, hex, ok := strings.Cut(digest, ":")
+	if !ok || alg == "" || hex == "" {
+		return "", fmt.Errorf("malformed digest %q", digest)
+	}
+	return path.Join("blobs", alg, hex), nil
+}
+
+// normalizeMember strips the "./" prefix some writers emit so member names compare equal to the layout-relative paths used here
+func normalizeMember(name string) string {
+	return strings.TrimPrefix(path.Clean(name), "./")
+}

--- a/internal/ociarchive/extract.go
+++ b/internal/ociarchive/extract.go
@@ -1,0 +1,362 @@
+package ociarchive
+
+import (
+	"archive/tar"
+	"bufio"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// whiteout markers defined by the OCI layer specification
+const (
+	whiteoutPrefix = ".wh."
+	whiteoutOpaque = ".wh..wh..opq"
+)
+
+type Result struct {
+	Files    int
+	Dirs     int
+	Symlinks int
+	Bytes    int64
+	Warnings []string
+}
+
+func (a *Archive) ExtractSubtree(img Image, subtree, dest string) (Result, error) {
+	var res Result
+
+	prefix := normalizeSubtree(subtree)
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		return res, fmt.Errorf("creating %s: %w", dest, err)
+	}
+
+	dirTimes := map[string]time.Time{}
+
+	for i, layer := range img.layers {
+		if foreignLayerMediaTypes[layer.MediaType] {
+			res.Warnings = append(res.Warnings,
+				fmt.Sprintf("layer %d (%s) is a foreign layer and is not held in the archive; skipped", i, layer.Digest))
+			continue
+		}
+		if err := a.applyLayer(layer, prefix, dest, dirTimes, &res); err != nil {
+			return res, fmt.Errorf("layer %d (%s): %w", i, layer.Digest, err)
+		}
+	}
+
+	// deepest first, so a parent's timestamp is not disturbed by later work
+	paths := make([]string, 0, len(dirTimes))
+	for p := range dirTimes {
+		paths = append(paths, p)
+	}
+	sort.Slice(paths, func(i, j int) bool { return len(paths[i]) > len(paths[j]) })
+	for _, p := range paths {
+		_ = os.Chtimes(p, dirTimes[p], dirTimes[p])
+	}
+
+	return res, nil
+}
+
+// applyLayer writes one layer's contribution to the subtree over whatever earlier layers left in dest
+func (a *Archive) applyLayer(desc Descriptor, prefix, dest string, dirTimes map[string]time.Time, res *Result) error {
+	rc, err := a.openLayer(desc)
+	if err != nil {
+		return err
+	}
+	defer rc.Close()
+
+	tr := tar.NewReader(rc)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("reading layer contents: %w", err)
+		}
+
+		name := normalizeMember(hdr.Name)
+
+		// a whiteout of the subtree root itself sits in the parent directory, so it is not matched by the prefix test below and must be caught
+		if prefix != "" && name == path.Join(path.Dir(prefix), whiteoutPrefix+path.Base(prefix)) {
+			if err := removeContents(dest); err != nil {
+				return err
+			}
+			clearPrefixed(dirTimes, dest)
+			continue
+		}
+
+		rel, ok := relTo(name, prefix)
+		if !ok {
+			continue
+		}
+
+		base := path.Base(rel)
+		switch {
+		case rel == ".wh..wh..opq" || base == whiteoutOpaque:
+			// opaque whiteout: everything the lower layers put in this directory is hidden, but entries from this same layer still apply
+			dir, err := safeJoin(dest, path.Dir(rel))
+			if err != nil {
+				res.Warnings = append(res.Warnings, err.Error())
+				continue
+			}
+			if err := removeContents(dir); err != nil {
+				return err
+			}
+			clearPrefixed(dirTimes, dir)
+			continue
+
+		case strings.HasPrefix(base, whiteoutPrefix):
+			target, err := safeJoin(dest, path.Join(path.Dir(rel), strings.TrimPrefix(base, whiteoutPrefix)))
+			if err != nil {
+				res.Warnings = append(res.Warnings, err.Error())
+				continue
+			}
+			if err := os.RemoveAll(target); err != nil {
+				return fmt.Errorf("applying whiteout %s: %w", name, err)
+			}
+			delete(dirTimes, target)
+			continue
+		}
+
+		target, err := safeJoin(dest, rel)
+		if err != nil {
+			res.Warnings = append(res.Warnings, err.Error())
+			continue
+		}
+
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, os.FileMode(hdr.Mode).Perm()); err != nil {
+				return fmt.Errorf("creating directory %s: %w", target, err)
+			}
+			if err := os.Chmod(target, os.FileMode(hdr.Mode).Perm()); err != nil {
+				return fmt.Errorf("setting mode on %s: %w", target, err)
+			}
+			dirTimes[target] = hdr.ModTime
+			if rel != "" {
+				res.Dirs++
+			}
+
+		case tar.TypeReg:
+			n, err := writeFile(target, tr, hdr)
+			if err != nil {
+				return err
+			}
+			res.Files++
+			res.Bytes += n
+
+		case tar.TypeSymlink:
+			// stored verbatim; resolving it here would break library soname chains that point outside the extracted subtree
+			if err := replace(target); err != nil {
+				return err
+			}
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return fmt.Errorf("creating parent of %s: %w", target, err)
+			}
+			if err := os.Symlink(hdr.Linkname, target); err != nil {
+				return fmt.Errorf("creating symlink %s: %w", target, err)
+			}
+			res.Symlinks++
+
+		case tar.TypeLink:
+			linkRel, ok := relTo(normalizeMember(hdr.Linkname), prefix)
+			if !ok {
+				res.Warnings = append(res.Warnings,
+					fmt.Sprintf("%s is a hard link to %s, which lies outside the extracted subtree; skipped", name, hdr.Linkname))
+				continue
+			}
+			source, err := safeJoin(dest, linkRel)
+			if err != nil {
+				res.Warnings = append(res.Warnings, err.Error())
+				continue
+			}
+			if err := replace(target); err != nil {
+				return err
+			}
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return fmt.Errorf("creating parent of %s: %w", target, err)
+			}
+			if err := os.Link(source, target); err != nil {
+				// a cross-device or unsupported link is recoverable: the point is to end up with the bytes, not to preserve the inode
+				n, copyErr := copyFileFrom(source, target, hdr)
+				if copyErr != nil {
+					res.Warnings = append(res.Warnings,
+						fmt.Sprintf("could not reproduce hard link %s -> %s: %v; skipped", name, hdr.Linkname, err))
+					continue
+				}
+				res.Bytes += n
+			}
+			res.Files++
+
+		default:
+			// character devices, block devices, and FIFOs cannot appear in a library tree and would need privileges to create
+			res.Warnings = append(res.Warnings,
+				fmt.Sprintf("%s has unsupported tar type %q; skipped", name, string(hdr.Typeflag)))
+		}
+	}
+}
+
+// openLayer streams a layer blob, transparently decompressing it
+func (a *Archive) openLayer(desc Descriptor) (io.ReadCloser, error) {
+	rc, err := a.openBlob(desc.Digest)
+	if err != nil {
+		return nil, err
+	}
+
+	br := bufio.NewReader(rc)
+	magic, _ := br.Peek(4)
+
+	switch {
+	case len(magic) >= 2 && magic[0] == 0x1f && magic[1] == 0x8b:
+		zr, err := gzip.NewReader(br)
+		if err != nil {
+			rc.Close()
+			return nil, fmt.Errorf("opening gzip layer %s: %w", desc.Digest, err)
+		}
+		return &layerReader{r: zr, closers: []io.Closer{zr, rc}}, nil
+
+	case len(magic) >= 4 && magic[0] == 0x28 && magic[1] == 0xb5 && magic[2] == 0x2f && magic[3] == 0xfd:
+		rc.Close()
+		return nil, fmt.Errorf("layer %s is zstd-compressed, which is not supported; rebuild the image with gzip layers (the buildx default) or re-save it with `skopeo copy --format oci`", desc.Digest)
+
+	default:
+		return &layerReader{r: br, closers: []io.Closer{rc}}, nil
+	}
+}
+
+type layerReader struct {
+	r       io.Reader
+	closers []io.Closer
+}
+
+func (l *layerReader) Read(p []byte) (int, error) { return l.r.Read(p) }
+
+func (l *layerReader) Close() error {
+	var firstErr error
+	for _, c := range l.closers {
+		if err := c.Close(); err != nil && firstErr == nil {
+			firstErr = err
+		}
+	}
+	return firstErr
+}
+
+// writeFile writes a regular file, replacing whatever a lower layer left there
+func writeFile(target string, r io.Reader, hdr *tar.Header) (int64, error) {
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		return 0, fmt.Errorf("creating parent of %s: %w", target, err)
+	}
+	if err := replace(target); err != nil {
+		return 0, err
+	}
+	f, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_EXCL, os.FileMode(hdr.Mode).Perm())
+	if err != nil {
+		return 0, fmt.Errorf("creating %s: %w", target, err)
+	}
+	n, err := io.Copy(f, r)
+	if closeErr := f.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		return n, fmt.Errorf("writing %s: %w", target, err)
+	}
+	if err := os.Chmod(target, os.FileMode(hdr.Mode).Perm()); err != nil {
+		return n, fmt.Errorf("setting mode on %s: %w", target, err)
+	}
+	if err := os.Chtimes(target, hdr.ModTime, hdr.ModTime); err != nil {
+		return n, fmt.Errorf("setting times on %s: %w", target, err)
+	}
+	return n, nil
+}
+
+// copyFileFrom duplicates an already-extracted file, used when a hard link cannot be created
+func copyFileFrom(source, target string, hdr *tar.Header) (int64, error) {
+	in, err := os.Open(source)
+	if err != nil {
+		return 0, err
+	}
+	defer in.Close()
+	return writeFile(target, in, hdr)
+}
+
+// replace clears any existing entry at target
+func replace(target string) error {
+	if _, err := os.Lstat(target); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if err := os.RemoveAll(target); err != nil {
+		return fmt.Errorf("replacing %s: %w", target, err)
+	}
+	return nil
+}
+
+// removeContents empties a directory without removing the directory itself
+func removeContents(dir string) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("reading %s: %w", dir, err)
+	}
+	for _, e := range entries {
+		if err := os.RemoveAll(filepath.Join(dir, e.Name())); err != nil {
+			return fmt.Errorf("clearing %s: %w", dir, err)
+		}
+	}
+	return nil
+}
+
+// clearPrefixed drops recorded directory times beneath a path that was emptied, so a stale entry cannot resurrect a timestamp for a directory that is gone
+func clearPrefixed(dirTimes map[string]time.Time, root string) {
+	for p := range dirTimes {
+		if p != root && strings.HasPrefix(p, root+string(os.PathSeparator)) {
+			delete(dirTimes, p)
+		}
+	}
+}
+
+// normalizeSubtree turns a caller-supplied path such as "/opt/coral/lib" into the layout used inside a layer tar
+func normalizeSubtree(subtree string) string {
+	s := strings.Trim(subtree, "/")
+	if s == "" || s == "." {
+		return ""
+	}
+	return strings.TrimPrefix(path.Clean(s), "./")
+}
+
+// relTo reports whether name lies at or beneath prefix, and its path relative to it
+func relTo(name, prefix string) (string, bool) {
+	if prefix == "" {
+		return name, true
+	}
+	if name == prefix {
+		return "", true
+	}
+	if strings.HasPrefix(name, prefix+"/") {
+		return name[len(prefix)+1:], true
+	}
+	return "", false
+}
+
+// safeJoin resolves rel beneath dest, refusing anything that would escape it
+func safeJoin(dest, rel string) (string, error) {
+	if rel == "" || rel == "." {
+		return dest, nil
+	}
+	cleaned := strings.TrimPrefix(path.Clean("/"+rel), "/")
+	target := filepath.Join(dest, filepath.FromSlash(cleaned))
+	if target != dest && !strings.HasPrefix(target, dest+string(os.PathSeparator)) {
+		return "", fmt.Errorf("entry %q would escape the output directory; skipped", rel)
+	}
+	return target, nil
+}


### PR DESCRIPTION
Added `extract` command to extract contents of `CORAL_EXPORT_LIB` from OCI formatted `.tar` archives. If the archive is a multi-platform image, the contents associated with all platforms will be extracted.

Used for generating Valence payloads.